### PR TITLE
Fix login route template path

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -7,7 +7,7 @@ def login():
     """Display login page with OAuth options."""
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
-    return render_template('auth/login.html')
+    return render_template('main/login.html')
 
 @bp.route('/logout')
 def logout():


### PR DESCRIPTION
## Summary
- correct the login route to use the template in the main blueprint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7763cd288327a42c3ada2c2eba10