### PR TITLE
Add athlete-related tables and basic auth

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -1,0 +1,17 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField
+from wtforms.validators import DataRequired, Email, EqualTo, Length
+
+class LoginForm(FlaskForm):
+    username_or_email = StringField('Username or Email', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    submit = SubmitField('Login')
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired(), Length(min=3, max=50)])
+    email = StringField('Email', validators=[DataRequired(), Email(), Length(max=255)])
+    first_name = StringField('First Name', validators=[DataRequired(), Length(max=100)])
+    last_name = StringField('Last Name', validators=[DataRequired(), Length(max=100)])
+    password = PasswordField('Password', validators=[DataRequired(), Length(min=6)])
+    confirm = PasswordField('Confirm Password', validators=[DataRequired(), EqualTo('password')])
+    submit = SubmitField('Register')

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,13 +1,31 @@
-from flask import render_template, redirect, url_for, flash
+from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, current_user
+from app import db
+from app.models import User, UserStatus
+from .forms import LoginForm, RegistrationForm
 from . import bp  # Fixed: import from current module
 
-@bp.route('/login')
+@bp.route('/login', methods=['GET', 'POST'])
 def login():
-    """Display login page with OAuth options."""
+    """Simple username/email and password login."""
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
-    return render_template('auth/login.html')
+
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter(
+            (User.username == form.username_or_email.data) |
+            (User.email == form.username_or_email.data)
+        ).first()
+        if user and user.check_password(form.password.data):
+            login_user(user)
+            user.login_count = (user.login_count or 0) + 1
+            db.session.commit()
+            flash('Logged in successfully.', 'success')
+            next_page = request.args.get('next')
+            return redirect(next_page or url_for('main.dashboard'))
+        flash('Invalid credentials.', 'danger')
+    return render_template('auth/login.html', form=form)
 
 @bp.route('/logout')
 def logout():
@@ -22,3 +40,26 @@ def oauth_login(provider):
     """Placeholder for OAuth login."""
     flash(f'OAuth login with {provider} not yet configured.', 'warning')
     return redirect(url_for('auth.login'))
+
+
+@bp.route('/register', methods=['GET', 'POST'])
+def register():
+    """Register a new user."""
+    if current_user.is_authenticated:
+        return redirect(url_for('main.dashboard'))
+
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        user = User(
+            username=form.username.data,
+            email=form.email.data,
+            first_name=form.first_name.data,
+            last_name=form.last_name.data,
+            status=UserStatus.ACTIVE,
+        )
+        user.set_password(form.password.data)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful. Please log in.', 'success')
+        return redirect(url_for('auth.login'))
+    return render_template('auth/register.html', form=form)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,10 +5,12 @@ from .oauth import OAuthProvider, UserOAuthAccount
 from .sports import Sport, Position
 from .user import User
 from .athlete import AthleteProfile
+from .athlete_extra import Athlete, AthleteStat, AthleteMedia, AthleteAchievement
 
 __all__ = [
     'BaseModel',
     'User', 'Role', 'UserRole', 
     'OAuthProvider', 'UserOAuthAccount',
-    'AthleteProfile', 'Sport', 'Position'
+    'AthleteProfile', 'Athlete', 'AthleteStat', 'AthleteMedia',
+    'AthleteAchievement', 'Sport', 'Position'
 ]

--- a/app/models/athlete_extra.py
+++ b/app/models/athlete_extra.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from app import db
+from app.models.base import BaseModel
+
+class Athlete(BaseModel):
+    __tablename__ = 'athletes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(100), nullable=False, index=True)
+    last_name = db.Column(db.String(100), nullable=False, index=True)
+    date_of_birth = db.Column(db.Date)
+    height = db.Column(db.Integer)
+    weight = db.Column(db.Integer)
+    position = db.Column(db.String(50))
+    sport_type = db.Column(db.String(50))
+    team_history = db.Column(db.JSON)
+
+    stats = db.relationship('AthleteStat', back_populates='athlete', cascade='all, delete-orphan')
+    media = db.relationship('AthleteMedia', back_populates='athlete', cascade='all, delete-orphan')
+    achievements = db.relationship('AthleteAchievement', back_populates='athlete', cascade='all, delete-orphan')
+
+    __table_args__ = (
+        db.Index('idx_athletes_name', 'last_name', 'first_name'),
+    )
+
+    def __repr__(self):
+        return f'<Athlete {self.first_name} {self.last_name}>'
+
+class AthleteStat(BaseModel):
+    __tablename__ = 'athlete_stats'
+
+    id = db.Column(db.Integer, primary_key=True)
+    athlete_id = db.Column(db.Integer, db.ForeignKey('athletes.id', ondelete='CASCADE'), nullable=False, index=True)
+    stat_type = db.Column(db.String(100), nullable=False)
+    stat_value = db.Column(db.Numeric, nullable=False)
+    season = db.Column(db.String(20))
+
+    athlete = db.relationship('Athlete', back_populates='stats')
+
+    __table_args__ = (
+        db.Index('idx_stats_athlete_season', 'athlete_id', 'season'),
+    )
+
+class AthleteMedia(BaseModel):
+    __tablename__ = 'athlete_media'
+
+    id = db.Column(db.Integer, primary_key=True)
+    athlete_id = db.Column(db.Integer, db.ForeignKey('athletes.id', ondelete='CASCADE'), nullable=False, index=True)
+    media_type = db.Column(db.String(50))
+    file_path = db.Column(db.String(255))
+    file_name = db.Column(db.String(255))
+    file_size = db.Column(db.Integer)
+    upload_date = db.Column(db.DateTime, default=datetime.utcnow)
+    description = db.Column(db.Text)
+    tags = db.Column(db.JSON)
+
+    athlete = db.relationship('Athlete', back_populates='media')
+
+    __table_args__ = (
+        db.Index('idx_media_athlete_type', 'athlete_id', 'media_type'),
+    )
+
+class AthleteAchievement(BaseModel):
+    __tablename__ = 'athlete_achievements'
+
+    id = db.Column(db.Integer, primary_key=True)
+    athlete_id = db.Column(db.Integer, db.ForeignKey('athletes.id', ondelete='CASCADE'), nullable=False, index=True)
+    achievement_type = db.Column(db.String(100))
+    description = db.Column(db.Text)
+    date_achieved = db.Column(db.Date)
+
+    athlete = db.relationship('Athlete', back_populates='achievements')
+
+    __table_args__ = (
+        db.Index('idx_achievements_athlete', 'athlete_id'),
+    )

--- a/run.py
+++ b/run.py
@@ -8,14 +8,28 @@ app = create_app(os.getenv('FLASK_ENV') or 'development')
 @app.shell_context_processor
 def make_shell_context():
     # Import models here to avoid circular imports
-    from app.models import User, Role, AthleteProfile, Sport, Position
+    from app.models import (
+        User,
+        Role,
+        AthleteProfile,
+        Athlete,
+        AthleteStat,
+        AthleteMedia,
+        AthleteAchievement,
+        Sport,
+        Position,
+    )
     return {
         'db': db,
         'User': User,
         'Role': Role,
         'AthleteProfile': AthleteProfile,
+        'Athlete': Athlete,
+        'AthleteStat': AthleteStat,
+        'AthleteMedia': AthleteMedia,
+        'AthleteAchievement': AthleteAchievement,
         'Sport': Sport,
-        'Position': Position
+        'Position': Position,
     }
 
 @app.cli.command()

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}Login - {{ super() }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-4">
+        <div class="card shadow">
+            <div class="card-body">
+                <h2 class="card-title text-center mb-4">Login</h2>
+                <form method="POST">
+                    {{ form.hidden_tag() }}
+                    <div class="mb-3">
+                        {{ form.username_or_email.label(class="form-label") }}
+                        {{ form.username_or_email(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.password.label(class="form-label") }}
+                        {{ form.password(class="form-control") }}
+                    </div>
+                    <div class="d-grid">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+                <hr>
+                <p class="text-center">
+                    Don't have an account? <a href="{{ url_for('auth.register') }}">Register</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Register - {{ super() }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-4">
+        <div class="card shadow">
+            <div class="card-body">
+                <h2 class="card-title text-center mb-4">Register</h2>
+                <form method="POST">
+                    {{ form.hidden_tag() }}
+                    <div class="mb-3">
+                        {{ form.username.label(class="form-label") }}
+                        {{ form.username(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.email.label(class="form-label") }}
+                        {{ form.email(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.first_name.label(class="form-label") }}
+                        {{ form.first_name(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.last_name.label(class="form-label") }}
+                        {{ form.last_name(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.password.label(class="form-label") }}
+                        {{ form.password(class="form-control") }}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.confirm.label(class="form-label") }}
+                        {{ form.confirm(class="form-control") }}
+                    </div>
+                    <div class="d-grid">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+                <hr>
+                <p class="text-center">
+                    Already have an account? <a href="{{ url_for('auth.login') }}">Login</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/main/base.html
+++ b/templates/main/base.html
@@ -24,6 +24,7 @@
                 <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
                 {% else %}
                 <a class="nav-link" href="{{ url_for('auth.login') }}">Login</a>
+                <a class="nav-link" href="{{ url_for('auth.register') }}">Register</a>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add athlete, stats, media and achievement models
- expose new models to shell context
- create login and registration forms and routes
- add templates for login and registration and navigation links
- enable compilation checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d7b3ec4608327b9a6d91682cd1c49