### PR TITLE
Implement basic athlete API with media and stats

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,9 @@ def create_app(config_name='development'):
     
     from app.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    from app.api import bp as api_bp
+    app.register_blueprint(api_bp, url_prefix='/api')
     
     # User loader for Flask-Login
     @login_manager.user_loader

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint('api', __name__)
+
+from app.api import routes

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,0 +1,117 @@
+from flask import request, jsonify, send_file, abort
+from app.api import bp
+from app import db
+from app.models import AthleteProfile, AthleteMedia, AthleteStat
+from app.services.media_service import MediaService
+
+@bp.route('/athletes', methods=['POST'])
+def create_athlete():
+    data = request.get_json() or {}
+    athlete = AthleteProfile(
+        user_id=data.get('user_id'),
+        primary_sport_id=data.get('primary_sport_id'),
+        primary_position_id=data.get('primary_position_id'),
+        date_of_birth=data.get('date_of_birth'),
+    )
+    db.session.add(athlete)
+    db.session.commit()
+    return jsonify(athlete.to_dict()), 201
+
+@bp.route('/athletes/<athlete_id>', methods=['GET'])
+def get_athlete(athlete_id):
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    return jsonify(athlete.to_dict())
+
+@bp.route('/athletes/<athlete_id>', methods=['PUT'])
+def update_athlete(athlete_id):
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    data = request.get_json() or {}
+    for field in ['primary_sport_id', 'primary_position_id', 'bio']:
+        if field in data:
+            setattr(athlete, field, data[field])
+    db.session.commit()
+    return jsonify(athlete.to_dict())
+
+@bp.route('/athletes/<athlete_id>', methods=['DELETE'])
+def delete_athlete(athlete_id):
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    athlete.is_deleted = True
+    db.session.commit()
+    return '', 204
+
+@bp.route('/athletes', methods=['GET'])
+def list_athletes():
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 10, type=int)
+    q = AthleteProfile.query.filter_by(is_deleted=False)
+    pagination = q.paginate(page=page, per_page=per_page, error_out=False)
+    data = [a.to_dict() for a in pagination.items]
+    return jsonify({'items': data, 'total': pagination.total})
+
+# Media endpoints
+@bp.route('/athletes/<athlete_id>/media', methods=['POST'])
+def upload_media(athlete_id):
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    if 'file' not in request.files:
+        abort(400, 'No file provided')
+    file = request.files['file']
+    media_type = request.form.get('media_type', 'other')
+    path, filename = MediaService.save_file(file, athlete_id, media_type)
+    media = AthleteMedia(
+        athlete_id=athlete_id,
+        media_type=media_type,
+        file_path=path,
+        original_filename=file.filename,
+    )
+    db.session.add(media)
+    db.session.commit()
+    return jsonify(media.to_dict()), 201
+
+@bp.route('/athletes/<athlete_id>/media', methods=['GET'])
+def list_media(athlete_id):
+    AthleteProfile.query.get_or_404(athlete_id)
+    media = AthleteMedia.query.filter_by(athlete_id=athlete_id).all()
+    return jsonify([m.to_dict() for m in media])
+
+@bp.route('/media/<media_id>', methods=['DELETE'])
+def delete_media(media_id):
+    media = AthleteMedia.query.get_or_404(media_id)
+    MediaService.delete_file(media.file_path)
+    db.session.delete(media)
+    db.session.commit()
+    return '', 204
+
+@bp.route('/media/<media_id>/download', methods=['GET'])
+def download_media(media_id):
+    media = AthleteMedia.query.get_or_404(media_id)
+    return send_file(media.file_path, as_attachment=True, download_name=media.original_filename)
+
+# Stats endpoints
+@bp.route('/athletes/<athlete_id>/stats', methods=['POST'])
+def add_or_update_stat(athlete_id):
+    AthleteProfile.query.get_or_404(athlete_id)
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        abort(400, 'Missing stat name')
+    stat = AthleteStat.query.filter_by(athlete_id=athlete_id, name=name).first()
+    if stat:
+        stat.value = data.get('value')
+    else:
+        stat = AthleteStat(athlete_id=athlete_id, name=name, value=data.get('value'))
+        db.session.add(stat)
+    db.session.commit()
+    return jsonify(stat.to_dict())
+
+@bp.route('/athletes/<athlete_id>/stats', methods=['GET'])
+def get_stats(athlete_id):
+    AthleteProfile.query.get_or_404(athlete_id)
+    stats = AthleteStat.query.filter_by(athlete_id=athlete_id).all()
+    return jsonify([s.to_dict() for s in stats])
+
+@bp.route('/stats/<stat_id>', methods=['DELETE'])
+def delete_stat(stat_id):
+    stat = AthleteStat.query.get_or_404(stat_id)
+    db.session.delete(stat)
+    db.session.commit()
+    return '', 204

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,10 +5,13 @@ from .oauth import OAuthProvider, UserOAuthAccount
 from .sports import Sport, Position
 from .user import User
 from .athlete import AthleteProfile
+from .media import AthleteMedia
+from .stats import AthleteStat
 
 __all__ = [
     'BaseModel',
     'User', 'Role', 'UserRole', 
     'OAuthProvider', 'UserOAuthAccount',
-    'AthleteProfile', 'Sport', 'Position'
+    'AthleteProfile', 'Sport', 'Position',
+    'AthleteMedia', 'AthleteStat'
 ]

--- a/app/models/athlete.py
+++ b/app/models/athlete.py
@@ -33,6 +33,7 @@ class AthleteProfile(BaseModel):
     years_professional = db.Column(db.Integer)
     current_team = db.Column(db.String(100))
     jersey_number = db.Column(db.String(5))
+    is_deleted = db.Column(db.Boolean, default=False)
     
     # Profile information
     bio = db.Column(db.Text)

--- a/app/models/media.py
+++ b/app/models/media.py
@@ -1,0 +1,21 @@
+from app import db
+from app.models.base import BaseModel
+import uuid
+
+class AthleteMedia(BaseModel):
+    __tablename__ = 'athlete_media'
+
+    media_id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    athlete_id = db.Column(db.String(36), db.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False)
+    media_type = db.Column(db.String(20))
+    file_path = db.Column(db.String(255), nullable=False)
+    original_filename = db.Column(db.String(255))
+
+    athlete = db.relationship('AthleteProfile', backref='media')
+
+    __table_args__ = (
+        db.Index('idx_media_athlete', 'athlete_id'),
+    )
+
+    def __repr__(self):
+        return f'<AthleteMedia {self.media_id}>'

--- a/app/models/stats.py
+++ b/app/models/stats.py
@@ -1,0 +1,20 @@
+from app import db
+from app.models.base import BaseModel
+import uuid
+
+class AthleteStat(BaseModel):
+    __tablename__ = 'athlete_stats'
+
+    stat_id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    athlete_id = db.Column(db.String(36), db.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    value = db.Column(db.String(100))
+
+    athlete = db.relationship('AthleteProfile', backref='stats')
+
+    __table_args__ = (
+        db.Index('idx_stats_athlete', 'athlete_id'),
+    )
+
+    def __repr__(self):
+        return f'<AthleteStat {self.stat_id}>'

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -1,0 +1,27 @@
+import os
+import uuid
+from werkzeug.utils import secure_filename
+
+class MediaService:
+    BASE_DIR = 'storage'
+
+    @staticmethod
+    def athlete_media_path(athlete_id, media_type):
+        return os.path.join(MediaService.BASE_DIR, 'athletes', athlete_id, media_type)
+
+    @staticmethod
+    def save_file(file_storage, athlete_id, media_type):
+        directory = MediaService.athlete_media_path(athlete_id, media_type)
+        os.makedirs(directory, exist_ok=True)
+        ext = os.path.splitext(file_storage.filename)[1]
+        filename = f"{uuid.uuid4().hex}{ext}"
+        path = os.path.join(directory, secure_filename(filename))
+        file_storage.save(path)
+        return path, filename
+
+    @staticmethod
+    def delete_file(path):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary
- add API blueprint with CRUD routes for athletes
- support athlete media upload and simple stats management
- create service for file storage
- introduce models for media and stats
- register API blueprint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7d7e02f8832799d5a8ff2f15fa5c