### PR TITLE
Add athlete search API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Pro Sports - Talent Agency
+
+## API Endpoints
+
+### Search Athletes
+`GET /api/athletes/search`
+
+Query parameters:
+- `q` – text search across athlete name, position and current team
+- `sport` – sport code or id
+- `min_age` / `max_age` – filter by age range
+- `min_height` / `max_height` – filter by height in centimeters
+- `min_weight` / `max_weight` – filter by weight in kilograms
+
+The endpoint returns a JSON object containing the matched athletes ordered by overall rating.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,21 @@ def create_app(config_name='development'):
     
     from app.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    from app.api import bp as api_bp
+    app.register_blueprint(api_bp)
+
+    if not app.debug and not app.testing:
+        import logging
+        from logging.handlers import RotatingFileHandler
+        import os
+        if not os.path.exists('logs'):
+            os.mkdir('logs')
+        file_handler = RotatingFileHandler('logs/app.log', maxBytes=10240, backupCount=10)
+        formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s')
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(logging.INFO)
+        app.logger.addHandler(file_handler)
     
     # User loader for Flask-Login
     @login_manager.user_loader

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint('api', __name__, url_prefix='/api')
+
+from app.api import athletes

--- a/app/api/athletes.py
+++ b/app/api/athletes.py
@@ -1,0 +1,89 @@
+from flask import request, jsonify, current_app
+from datetime import date
+from functools import lru_cache
+from sqlalchemy import or_, and_
+
+from app.api import bp
+from app import db
+from app.models import AthleteProfile, User, Sport, Position
+
+# Simple in-memory cache for search results
+_SEARCH_CACHE_SIZE = 128
+
+
+def _cache_key(args):
+    key_parts = [f"{k}={v}" for k, v in sorted(args.items())]
+    return '&'.join(key_parts)
+
+
+@lru_cache(maxsize=_SEARCH_CACHE_SIZE)
+def _cached_search(key):
+    """Perform the actual database search using a cache key."""
+    params = dict(item.split('=', 1) for item in key.split('&') if '=' in item)
+    q = params.get('q', '')
+    sport = params.get('sport')
+    min_age = int(params['min_age']) if 'min_age' in params else None
+    max_age = int(params['max_age']) if 'max_age' in params else None
+    min_height = int(params['min_height']) if 'min_height' in params else None
+    max_height = int(params['max_height']) if 'max_height' in params else None
+    min_weight = float(params['min_weight']) if 'min_weight' in params else None
+    max_weight = float(params['max_weight']) if 'max_weight' in params else None
+
+    query = AthleteProfile.query.join(User).outerjoin(Sport).outerjoin(Position)
+
+    if sport:
+        if sport.isdigit():
+            query = query.filter(AthleteProfile.primary_sport_id == int(sport))
+        else:
+            query = query.filter(Sport.code.ilike(sport))
+
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(
+            or_(
+                User.first_name.ilike(pattern),
+                User.last_name.ilike(pattern),
+                Position.name.ilike(pattern),
+                AthleteProfile.current_team.ilike(pattern),
+            )
+        )
+
+    today = date.today()
+    if min_age is not None:
+        cutoff = today.replace(year=today.year - min_age)
+        query = query.filter(AthleteProfile.date_of_birth <= cutoff)
+    if max_age is not None:
+        cutoff = today.replace(year=today.year - max_age)
+        query = query.filter(AthleteProfile.date_of_birth >= cutoff)
+
+    if min_height is not None:
+        query = query.filter(AthleteProfile.height_cm >= min_height)
+    if max_height is not None:
+        query = query.filter(AthleteProfile.height_cm <= max_height)
+
+    if min_weight is not None:
+        query = query.filter(AthleteProfile.weight_kg >= min_weight)
+    if max_weight is not None:
+        query = query.filter(AthleteProfile.weight_kg <= max_weight)
+
+    results = (
+        query.order_by(AthleteProfile.overall_rating.desc())
+        .limit(50)
+        .all()
+    )
+
+    return [ath.to_dict() for ath in results]
+
+
+@bp.route('/athletes/search')
+def search_athletes():
+    """Search athletes with optional filters."""
+    args = request.args.to_dict(flat=True)
+    key = _cache_key(args)
+    results = _cached_search(key)
+
+    # Simple analytics logging
+    if current_app:
+        current_app.logger.info('search query: %s', key)
+
+    return jsonify({'results': results, 'count': len(results)})


### PR DESCRIPTION
## Summary
- implement `/api/athletes/search` endpoint with filter parsing and basic ranking
- register new API blueprint and enable file logging
- document new search API in README

## Testing
- `python -m py_compile app/api/__init__.py app/api/athletes.py app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685d7e9a363c8327996a81b656626ff1