### PR TITLE
Add API layer and frontend client

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,9 @@ def create_app(config_name='development'):
     
     from app.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    from app.api import bp as api_bp
+    app.register_blueprint(api_bp, url_prefix='/api')
     
     # User loader for Flask-Login
     @login_manager.user_loader

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, jsonify, abort
+from app.models import AthleteProfile
+
+bp = Blueprint('api', __name__)
+
+@bp.route('/athletes/<string:athlete_id>')
+def get_athlete(athlete_id):
+    athlete = AthleteProfile.query.get(athlete_id)
+    if not athlete:
+        abort(404)
+    return jsonify(athlete.to_dict())

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -12,3 +12,9 @@ def index():
 def dashboard():
     """User dashboard."""
     return render_template('main/dashboard.html')
+
+
+@bp.route('/athletes/<string:athlete_id>')
+def athlete_view(athlete_id):
+    """Page displaying a single athlete."""
+    return render_template('main/athlete.html', athlete_id=athlete_id)

--- a/static/js/apiClient.js
+++ b/static/js/apiClient.js
@@ -1,0 +1,21 @@
+export async function fetchWithRetry(url, options = {}, retries = 3) {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (!res.ok) throw new Error('Request failed');
+      return await res.json();
+    } catch (err) {
+      if (attempt === retries - 1) throw err;
+      await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+    }
+  }
+}
+
+const cache = new Map();
+
+export async function getAthlete(id) {
+  if (cache.has(id)) return cache.get(id);
+  const data = await fetchWithRetry(`/api/athletes/${id}`);
+  cache.set(id, data);
+  return data;
+}

--- a/templates/main/athlete.html
+++ b/templates/main/athlete.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Athlete - {{ super() }}{% endblock %}
+
+{% block content %}
+<div id="athlete-container" class="text-center p-5">
+  <div id="loading" class="spinner-border" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module">
+import { getAthlete } from '/static/js/apiClient.js';
+const container = document.getElementById('athlete-container');
+const athleteId = '{{ athlete_id }}';
+getAthlete(athleteId).then(data => {
+  container.innerHTML = `<h2>${data.first_name} ${data.last_name}</h2>`;
+}).catch(() => {
+  container.innerHTML = '<div class="alert alert-danger">Failed to load athlete.</div>';
+});
+</script>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,34 @@
+import json
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User, AthleteProfile
+
+@pytest.fixture
+def app_instance():
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def test_get_athlete(client):
+    user = User(username='u1', email='u1@example.com', first_name='U', last_name='One')
+    user.save()
+    athlete = AthleteProfile(user_id=user.user_id, date_of_birth='2000-01-01')
+    athlete.save()
+
+    resp = client.get(f'/api/athletes/{athlete.athlete_id}')
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert data['athlete_id'] == athlete.athlete_id


### PR DESCRIPTION
## Summary
- add API blueprint and route for fetching athlete data
- register API blueprint in the Flask app
- create JS API client with retry & caching
- add athlete page with loading state using the client
- add simple integration test for the athlete API endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d806f9fc08327a1b2d8df26bc2c15