### PR TITLE
QA fix: restore auth login and API blueprint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,9 @@ def create_app(config_name='development'):
     from app.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
 
+    from app.api import bp as api_bp
+    app.register_blueprint(api_bp)
+
 
     # User loader for Flask-Login
     @login_manager.user_loader

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,8 @@
+"""API blueprint setup."""
+
+from flask import Blueprint
+
+bp = Blueprint("api", __name__, url_prefix="/api")
+
+# Import routes to register view functions with this blueprint
+from app.api import routes  # noqa: E402

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -8,9 +8,25 @@ from . import bp  # Fixed: import from current module
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
     """Simple username/email and password login."""
+
     if current_user.is_authenticated:
         return redirect(url_for('main.dashboard'))
 
+    form = LoginForm()
+    if form.validate_on_submit():
+        identifier = form.username_or_email.data
+        user = (
+            User.query.filter(
+                (User.username == identifier) | (User.email == identifier)
+            ).first()
+        )
+        if user and user.check_password(form.password.data):
+            login_user(user)
+            flash('Logged in successfully.', 'success')
+            return redirect(url_for('main.dashboard'))
+        flash('Invalid username/email or password.', 'danger')
+
+    return render_template('auth/login.html', form=form)
 
 @bp.route('/logout')
 def logout():


### PR DESCRIPTION
## Summary
- register API blueprint
- implement login form handling
- clean up API blueprint init

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685dabb6d4d08327b01a1a213c1a2a82