### PR TITLE
Add Flask-RESTX API docs

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,8 +1,18 @@
-"""API blueprint setup."""
+"""API blueprint setup using Flask-RESTX for documentation."""
 
 from flask import Blueprint
+from flask_restx import Api
 
 bp = Blueprint("api", __name__, url_prefix="/api")
 
-# Import routes to register view functions with this blueprint
-from app.api import routes  # noqa: E402
+# Configure the RESTX Api with Swagger documentation at /api/swagger
+api = Api(
+    bp,
+    title="Pro Sports API",
+    version="1.0",
+    description="Operations related to athletes",
+    doc="/swagger",
+)
+
+# Import resources to register endpoints with this Api
+from app.api import routes, athletes  # noqa: E402

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,117 +1,161 @@
-from flask import request, jsonify, send_file, abort
-from app.api import bp
+from flask import request, send_file, abort, jsonify
+from flask_restx import Resource
+
+from app.api import api
 from app import db
 from app.models import AthleteProfile, AthleteMedia, AthleteStat
 from app.services.media_service import MediaService
 
-@bp.route('/athletes', methods=['POST'])
-def create_athlete():
-    data = request.get_json() or {}
-    athlete = AthleteProfile(
-        user_id=data.get('user_id'),
-        primary_sport_id=data.get('primary_sport_id'),
-        primary_position_id=data.get('primary_position_id'),
-        date_of_birth=data.get('date_of_birth'),
-    )
-    db.session.add(athlete)
-    db.session.commit()
-    return jsonify(athlete.to_dict()), 201
 
-@bp.route('/athletes/<athlete_id>', methods=['GET'])
-def get_athlete(athlete_id):
-    athlete = AthleteProfile.query.get_or_404(athlete_id)
-    return jsonify(athlete.to_dict())
+@api.route('/athletes')
+class AthleteList(Resource):
+    """Create or list athletes."""
 
-@bp.route('/athletes/<athlete_id>', methods=['PUT'])
-def update_athlete(athlete_id):
-    athlete = AthleteProfile.query.get_or_404(athlete_id)
-    data = request.get_json() or {}
-    for field in ['primary_sport_id', 'primary_position_id', 'bio']:
-        if field in data:
-            setattr(athlete, field, data[field])
-    db.session.commit()
-    return jsonify(athlete.to_dict())
+    @api.doc(description="List athletes", params={
+        'page': 'Page number',
+        'per_page': 'Items per page'
+    })
+    def get(self):
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 10, type=int)
+        q = AthleteProfile.query.filter_by(is_deleted=False)
+        pagination = q.paginate(page=page, per_page=per_page, error_out=False)
+        data = [a.to_dict() for a in pagination.items]
+        return jsonify({'items': data, 'total': pagination.total})
 
-@bp.route('/athletes/<athlete_id>', methods=['DELETE'])
-def delete_athlete(athlete_id):
-    athlete = AthleteProfile.query.get_or_404(athlete_id)
-    athlete.is_deleted = True
-    db.session.commit()
-    return '', 204
+    @api.doc(description="Create a new athlete")
+    def post(self):
+        data = request.get_json() or {}
+        athlete = AthleteProfile(
+            user_id=data.get('user_id'),
+            primary_sport_id=data.get('primary_sport_id'),
+            primary_position_id=data.get('primary_position_id'),
+            date_of_birth=data.get('date_of_birth'),
+        )
+        db.session.add(athlete)
+        db.session.commit()
+        return jsonify(athlete.to_dict()), 201
 
-@bp.route('/athletes', methods=['GET'])
-def list_athletes():
-    page = request.args.get('page', 1, type=int)
-    per_page = request.args.get('per_page', 10, type=int)
-    q = AthleteProfile.query.filter_by(is_deleted=False)
-    pagination = q.paginate(page=page, per_page=per_page, error_out=False)
-    data = [a.to_dict() for a in pagination.items]
-    return jsonify({'items': data, 'total': pagination.total})
 
-# Media endpoints
-@bp.route('/athletes/<athlete_id>/media', methods=['POST'])
-def upload_media(athlete_id):
-    athlete = AthleteProfile.query.get_or_404(athlete_id)
-    if 'file' not in request.files:
-        abort(400, 'No file provided')
-    file = request.files['file']
-    media_type = request.form.get('media_type', 'other')
-    path, filename = MediaService.save_file(file, athlete_id, media_type)
-    media = AthleteMedia(
-        athlete_id=athlete_id,
-        media_type=media_type,
-        file_path=path,
-        original_filename=file.filename,
-    )
-    db.session.add(media)
-    db.session.commit()
-    return jsonify(media.to_dict()), 201
+@api.route('/athletes/<string:athlete_id>')
+@api.param('athlete_id', 'Athlete identifier')
+class AthleteResource(Resource):
+    """Retrieve, update or delete a single athlete."""
 
-@bp.route('/athletes/<athlete_id>/media', methods=['GET'])
-def list_media(athlete_id):
-    AthleteProfile.query.get_or_404(athlete_id)
-    media = AthleteMedia.query.filter_by(athlete_id=athlete_id).all()
-    return jsonify([m.to_dict() for m in media])
+    @api.doc(description="Get an athlete")
+    def get(self, athlete_id):
+        athlete = AthleteProfile.query.get_or_404(athlete_id)
+        return jsonify(athlete.to_dict())
 
-@bp.route('/media/<media_id>', methods=['DELETE'])
-def delete_media(media_id):
-    media = AthleteMedia.query.get_or_404(media_id)
-    MediaService.delete_file(media.file_path)
-    db.session.delete(media)
-    db.session.commit()
-    return '', 204
+    @api.doc(description="Update an athlete")
+    def put(self, athlete_id):
+        athlete = AthleteProfile.query.get_or_404(athlete_id)
+        data = request.get_json() or {}
+        for field in ['primary_sport_id', 'primary_position_id', 'bio']:
+            if field in data:
+                setattr(athlete, field, data[field])
+        db.session.commit()
+        return jsonify(athlete.to_dict())
 
-@bp.route('/media/<media_id>/download', methods=['GET'])
-def download_media(media_id):
-    media = AthleteMedia.query.get_or_404(media_id)
-    return send_file(media.file_path, as_attachment=True, download_name=media.original_filename)
+    @api.doc(description="Delete an athlete")
+    def delete(self, athlete_id):
+        athlete = AthleteProfile.query.get_or_404(athlete_id)
+        athlete.is_deleted = True
+        db.session.commit()
+        return '', 204
 
-# Stats endpoints
-@bp.route('/athletes/<athlete_id>/stats', methods=['POST'])
-def add_or_update_stat(athlete_id):
-    AthleteProfile.query.get_or_404(athlete_id)
-    data = request.get_json() or {}
-    name = data.get('name')
-    if not name:
-        abort(400, 'Missing stat name')
-    stat = AthleteStat.query.filter_by(athlete_id=athlete_id, name=name).first()
-    if stat:
-        stat.value = data.get('value')
-    else:
-        stat = AthleteStat(athlete_id=athlete_id, name=name, value=data.get('value'))
-        db.session.add(stat)
-    db.session.commit()
-    return jsonify(stat.to_dict())
 
-@bp.route('/athletes/<athlete_id>/stats', methods=['GET'])
-def get_stats(athlete_id):
-    AthleteProfile.query.get_or_404(athlete_id)
-    stats = AthleteStat.query.filter_by(athlete_id=athlete_id).all()
-    return jsonify([s.to_dict() for s in stats])
+@api.route('/athletes/<string:athlete_id>/media')
+@api.param('athlete_id', 'Athlete identifier')
+class AthleteMediaList(Resource):
+    """Upload or list athlete media."""
 
-@bp.route('/stats/<stat_id>', methods=['DELETE'])
-def delete_stat(stat_id):
-    stat = AthleteStat.query.get_or_404(stat_id)
-    db.session.delete(stat)
-    db.session.commit()
-    return '', 204
+    @api.doc(description="List media for an athlete")
+    def get(self, athlete_id):
+        AthleteProfile.query.get_or_404(athlete_id)
+        media = AthleteMedia.query.filter_by(athlete_id=athlete_id).all()
+        return jsonify([m.to_dict() for m in media])
+
+    @api.doc(description="Upload a media file", params={'file': 'File upload', 'media_type': 'Type of media'})
+    def post(self, athlete_id):
+        athlete = AthleteProfile.query.get_or_404(athlete_id)
+        if 'file' not in request.files:
+            abort(400, 'No file provided')
+        file = request.files['file']
+        media_type = request.form.get('media_type', 'other')
+        path, _ = MediaService.save_file(file, athlete_id, media_type)
+        media = AthleteMedia(
+            athlete_id=athlete_id,
+            media_type=media_type,
+            file_path=path,
+            original_filename=file.filename,
+        )
+        db.session.add(media)
+        db.session.commit()
+        return jsonify(media.to_dict()), 201
+
+
+@api.route('/media/<string:media_id>')
+@api.param('media_id', 'Media identifier')
+class MediaResource(Resource):
+    """Delete media."""
+
+    @api.doc(description="Delete a media entry")
+    def delete(self, media_id):
+        media = AthleteMedia.query.get_or_404(media_id)
+        MediaService.delete_file(media.file_path)
+        db.session.delete(media)
+        db.session.commit()
+        return '', 204
+
+
+@api.route('/media/<string:media_id>/download')
+@api.param('media_id', 'Media identifier')
+class MediaDownload(Resource):
+    """Download a media file."""
+
+    @api.doc(description="Download media")
+    def get(self, media_id):
+        media = AthleteMedia.query.get_or_404(media_id)
+        return send_file(media.file_path, as_attachment=True, download_name=media.original_filename)
+
+
+@api.route('/athletes/<string:athlete_id>/stats')
+@api.param('athlete_id', 'Athlete identifier')
+class AthleteStats(Resource):
+    """Add, update or list athlete stats."""
+
+    @api.doc(description="Get stats for an athlete")
+    def get(self, athlete_id):
+        AthleteProfile.query.get_or_404(athlete_id)
+        stats = AthleteStat.query.filter_by(athlete_id=athlete_id).all()
+        return jsonify([s.to_dict() for s in stats])
+
+    @api.doc(description="Add or update a stat")
+    def post(self, athlete_id):
+        AthleteProfile.query.get_or_404(athlete_id)
+        data = request.get_json() or {}
+        name = data.get('name')
+        if not name:
+            abort(400, 'Missing stat name')
+        stat = AthleteStat.query.filter_by(athlete_id=athlete_id, name=name).first()
+        if stat:
+            stat.value = data.get('value')
+        else:
+            stat = AthleteStat(athlete_id=athlete_id, name=name, value=data.get('value'))
+            db.session.add(stat)
+        db.session.commit()
+        return jsonify(stat.to_dict())
+
+
+@api.route('/stats/<string:stat_id>')
+@api.param('stat_id', 'Stat identifier')
+class StatResource(Resource):
+    """Delete a stat."""
+
+    @api.doc(description="Delete a stat")
+    def delete(self, stat_id):
+        stat = AthleteStat.query.get_or_404(stat_id)
+        db.session.delete(stat)
+        db.session.commit()
+        return '', 204

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Flask-Session==0.5.0
 email-validator==2.0.0
 requests==2.31.0
 pytest==8.1.1
+Flask-RESTX==1.3.0


### PR DESCRIPTION
## Summary
- integrate Flask-RESTX for swagger docs
- convert athlete endpoints to `Resource` classes
- document search and CRUD endpoints
- include Flask-RESTX dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685dad81cc808327992001c36520e09b