### PR TITLE
Refactor athlete CRUD logic into service module

### DIFF
--- a/app/services/athlete_service.py
+++ b/app/services/athlete_service.py
@@ -1,0 +1,44 @@
+from app import db
+from app.models import AthleteProfile
+
+
+def create_athlete(data):
+    """Create a new athlete profile from provided data."""
+    athlete = AthleteProfile(
+        user_id=data.get('user_id'),
+        primary_sport_id=data.get('primary_sport_id'),
+        primary_position_id=data.get('primary_position_id'),
+        date_of_birth=data.get('date_of_birth'),
+    )
+    db.session.add(athlete)
+    db.session.commit()
+    return athlete
+
+
+def get_athlete(athlete_id):
+    """Retrieve an athlete profile by id or raise 404."""
+    return AthleteProfile.query.get_or_404(athlete_id)
+
+
+def update_athlete(athlete_id, data):
+    """Update an existing athlete profile."""
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    for field in ['primary_sport_id', 'primary_position_id', 'bio']:
+        if field in data:
+            setattr(athlete, field, data[field])
+    db.session.commit()
+    return athlete
+
+
+def delete_athlete(athlete_id):
+    """Soft delete an athlete profile."""
+    athlete = AthleteProfile.query.get_or_404(athlete_id)
+    athlete.is_deleted = True
+    db.session.commit()
+    return True
+
+
+def list_athletes(page=1, per_page=10):
+    """Return a pagination object of non-deleted athletes."""
+    query = AthleteProfile.query.filter_by(is_deleted=False)
+    return query.paginate(page=page, per_page=per_page, error_out=False)


### PR DESCRIPTION
## Summary
- introduce `athlete_service` with CRUD helpers
- update athlete API routes to use new service functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685dad80c37c8327809a185c2e8633b9