### PR TITLE
Add media thumbnails and compression helpers

### DIFF
--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 from werkzeug.utils import secure_filename
+from PIL import Image
 
 class MediaService:
     BASE_DIR = 'storage'
@@ -25,3 +26,35 @@ class MediaService:
             os.remove(path)
         except FileNotFoundError:
             pass
+
+    @staticmethod
+    def create_thumbnail(image_path, size=(128, 128)):
+        """Create a thumbnail for the given image and return the path."""
+        img = Image.open(image_path)
+        img.thumbnail(size)
+        base, ext = os.path.splitext(image_path)
+        thumb_path = f"{base}_thumb{ext}"
+        img.save(thumb_path)
+        return thumb_path
+
+    @staticmethod
+    def compress_image(image_path, quality=80):
+        """Compress an image in-place using the specified quality."""
+        img = Image.open(image_path)
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
+        img.save(image_path, optimize=True, quality=quality)
+        return image_path
+
+    @staticmethod
+    def save_image(file_storage, athlete_id, media_type,
+                   create_thumbnail=False, thumbnail_size=(128, 128),
+                   compress=False, quality=80):
+        """Save an uploaded image with optional compression and thumbnail."""
+        path, filename = MediaService.save_file(file_storage, athlete_id, media_type)
+        if compress:
+            MediaService.compress_image(path, quality=quality)
+        thumb_path = None
+        if create_thumbnail:
+            thumb_path = MediaService.create_thumbnail(path, size=thumbnail_size)
+        return path, filename, thumb_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ email-validator==2.0.0
 requests==2.31.0
 pytest==8.1.1
 Flask-RESTX==1.3.0
+Pillow==10.2.0

--- a/tests/test_media_service.py
+++ b/tests/test_media_service.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.services.media_service import MediaService
+
+
+def test_create_thumbnail(tmp_path):
+    img_path = tmp_path / "img.jpg"
+    Image.new('RGB', (800, 600), color='red').save(img_path)
+
+    thumb_path = MediaService.create_thumbnail(str(img_path), size=(100, 100))
+    assert os.path.exists(thumb_path)
+    with Image.open(thumb_path) as thumb:
+        width, height = thumb.size
+        assert width <= 100 and height <= 100
+
+
+def test_compress_image(tmp_path):
+    img_path = tmp_path / "img.jpg"
+    Image.new('RGB', (800, 600), color='blue').save(img_path, quality=100)
+    original_size = img_path.stat().st_size
+
+    MediaService.compress_image(str(img_path), quality=50)
+    compressed_size = img_path.stat().st_size
+    assert compressed_size <= original_size
+
+
+def test_save_image_with_options(tmp_path):
+    img_path = tmp_path / "upload.jpg"
+    Image.new('RGB', (500, 400), color='green').save(img_path)
+
+    class FileStorageMock:
+        filename = 'upload.jpg'
+        def save(self, dst):
+            Image.open(img_path).save(dst)
+
+    path, filename, thumb = MediaService.save_image(
+        FileStorageMock(), 'a1', 'photos', create_thumbnail=True, compress=True, thumbnail_size=(50, 50), quality=40
+    )
+
+    assert os.path.exists(path)
+    assert os.path.exists(thumb)
+    assert filename in path


### PR DESCRIPTION
## Summary
- add Pillow for image manipulation
- extend `MediaService` with thumbnail and compression helpers
- add tests for new utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ddb465054832791232ac23ceed198