### PR TITLE
Add validation decorators and JSON error handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,10 @@
 from flask import Flask
+from flask import jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
 from config import config
+from werkzeug.exceptions import HTTPException
 
 # Initialize extensions
 db = SQLAlchemy()
@@ -36,6 +38,19 @@ def create_app(config_name='development'):
     from app.api import bp as api_bp
     app.register_blueprint(api_bp)
 
+    # Error handlers to return JSON responses
+    @app.errorhandler(HTTPException)
+    def handle_http_error(error):
+        response = jsonify({'error': error.description})
+        response.status_code = error.code or 500
+        return response
+
+    @app.errorhandler(Exception)
+    def handle_generic_error(error):
+        app.logger.exception(error)
+        response = jsonify({'error': 'Internal Server Error'})
+        response.status_code = 500
+        return response
 
     # User loader for Flask-Login
     @login_manager.user_loader

--- a/app/api/athletes.py
+++ b/app/api/athletes.py
@@ -1,4 +1,5 @@
 from flask import request, jsonify, current_app
+from app.utils.validators import validate_params
 from datetime import date
 from functools import lru_cache
 from sqlalchemy import or_
@@ -90,6 +91,7 @@ class AthleteSearch(Resource):
         'min_weight': 'Minimum weight (kg)',
         'max_weight': 'Maximum weight (kg)',
     }, description="Search athletes with optional filters")
+    @validate_params([])
     def get(self):
         args = request.args.to_dict(flat=True)
         key = _cache_key(args)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,5 @@
 from flask import request, send_file, abort, jsonify
+from app.utils.validators import validate_json, validate_params
 from flask_restx import Resource
 
 from app.api import api
@@ -32,6 +33,7 @@ class AthleteList(Resource):
         return jsonify({'items': data, 'total': pagination.total})
 
     @api.doc(description="Create a new athlete")
+    @validate_json(['user_id', 'primary_sport_id', 'primary_position_id', 'date_of_birth'])
     def post(self):
         data = request.get_json() or {}
         athlete = AthleteProfile(
@@ -56,6 +58,7 @@ class AthleteResource(Resource):
         return jsonify(athlete.to_dict())
 
     @api.doc(description="Update an athlete")
+    @validate_json([])
     def put(self, athlete_id):
         athlete = AthleteProfile.query.get_or_404(athlete_id)
         data = request.get_json() or {}
@@ -140,6 +143,7 @@ class AthleteStats(Resource):
         return jsonify([s.to_dict() for s in stats])
 
     @api.doc(description="Add or update a stat")
+    @validate_json(['name'])
     def post(self, athlete_id):
         AthleteProfile.query.get_or_404(athlete_id)
         data = request.get_json() or {}
@@ -169,6 +173,7 @@ class StatResource(Resource):
         return '', 204
       
 @bp.route('/athletes', methods=['POST'])
+@validate_json(['user_id', 'primary_sport_id', 'primary_position_id', 'date_of_birth'])
 def create_athlete():
     data = request.get_json() or {}
     athlete = create_athlete_service(data)
@@ -180,6 +185,7 @@ def get_athlete(athlete_id):
     return jsonify(athlete.to_dict())
 
 @bp.route('/athletes/<athlete_id>', methods=['PUT'])
+@validate_json([])
 def update_athlete(athlete_id):
     data = request.get_json() or {}
     athlete = update_athlete_service(athlete_id, data)
@@ -238,12 +244,11 @@ def download_media(media_id):
 
 # Stats endpoints
 @bp.route('/athletes/<athlete_id>/stats', methods=['POST'])
+@validate_json(['name'])
 def add_or_update_stat(athlete_id):
     AthleteProfile.query.get_or_404(athlete_id)
     data = request.get_json() or {}
     name = data.get('name')
-    if not name:
-        abort(400, 'Missing stat name')
     stat = AthleteStat.query.filter_by(athlete_id=athlete_id, name=name).first()
     if stat:
         stat.value = data.get('value')

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -1,0 +1,37 @@
+from functools import wraps
+from flask import request, abort
+
+
+def validate_json(required_fields):
+    """Ensure a JSON payload with required fields is present."""
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if not request.is_json:
+                abort(400, description="Invalid or missing JSON payload")
+            data = request.get_json() or {}
+            missing = [f for f in required_fields if f not in data]
+            if missing:
+                abort(400, description="Missing fields: " + ", ".join(missing))
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def validate_params(required_params):
+    """Ensure request args contain required query parameters."""
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            missing = [p for p in required_params if p not in request.args]
+            if missing:
+                abort(400, description="Missing parameters: " + ", ".join(missing))
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,3 +32,17 @@ def test_get_athlete(client):
     assert resp.status_code == 200
     data = json.loads(resp.data)
     assert data['athlete_id'] == athlete.athlete_id
+
+
+def test_create_athlete_missing_field(client):
+    resp = client.post('/api/athletes', json={})
+    assert resp.status_code == 400
+    data = json.loads(resp.data)
+    assert 'error' in data
+
+
+def test_404_returns_json(client):
+    resp = client.get('/api/athletes/nonexistent')
+    assert resp.status_code == 404
+    data = json.loads(resp.data)
+    assert 'error' in data


### PR DESCRIPTION
## Summary
- add decorators for JSON payload and query parameter validation
- return JSON-formatted error responses from middleware
- apply new decorators across API routes
- include utility package
- expand API tests for validation and error handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ddb4d3ec883279878be4860862819