### PR TITLE
Add Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV FLASK_APP=run.py
+ENV FLASK_ENV=development
+
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ Query parameters:
 - `min_weight` / `max_weight` – filter by weight in kilograms
 
 The endpoint returns a JSON object containing the matched athletes ordered by overall rating.
+
+## Local Development with Docker
+
+1. Ensure you have [Docker](https://docs.docker.com/get-docker/) installed.
+2. Build and start the containers:
+
+   ```bash
+   docker-compose up --build
+   ```
+3. Visit `http://localhost:5000` to access the application.
+4. PostgreSQL is exposed on port `5432` with default credentials `postgres/postgres` and the database `sport_agency_dev`.
+
+Application code is mounted into the container for live reloading during development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: sport_agency_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  web:
+    build: .
+    command: flask run --host=0.0.0.0 --port=5000
+    volumes:
+      - .:/app
+    ports:
+      - "5000:5000"
+    environment:
+      FLASK_ENV: development
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/sport_agency_dev
+    depends_on:
+      - db
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- create a `Dockerfile` for running the Flask app
- add a `docker-compose.yml` with app and PostgreSQL services
- document how to run the project with Docker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ddb4fee888327881deda8bd7f663a