### PR TITLE
Configure application logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Query parameters:
 - `min_weight` / `max_weight` – filter by weight in kilograms
 
 The endpoint returns a JSON object containing the matched athletes ordered by overall rating.
+
+## Logs
+
+Application logs are written to `logs/app.log` inside the project directory.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,29 +3,45 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager
 from config import config
+import logging
+from logging.handlers import RotatingFileHandler
+import os
 
 # Initialize extensions
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
 
+
 def create_app(config_name='development'):
     app = Flask(__name__, instance_relative_config=True)
-    
+
     # Load configuration
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
-    
+
     # Initialize extensions with app
     db.init_app(app)
     migrate.init_app(app, db)
     login_manager.init_app(app)
-    
+
+    # Configure logging
+    if not os.path.exists('logs'):
+        os.mkdir('logs')
+    file_handler = RotatingFileHandler('logs/app.log', maxBytes=10240, backupCount=10)
+    formatter = logging.Formatter(
+        '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
+    )
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.INFO)
+    app.logger.addHandler(file_handler)
+    app.logger.setLevel(logging.INFO)
+
     # Configure login manager
     login_manager.login_view = 'auth.login'
     login_manager.login_message = 'Please log in to access this page.'
     login_manager.login_message_category = 'info'
-    
+
     # Register Blueprints
     from app.main import bp as main_bp
     app.register_blueprint(main_bp)
@@ -36,11 +52,12 @@ def create_app(config_name='development'):
     from app.api import bp as api_bp
     app.register_blueprint(api_bp)
 
-
     # User loader for Flask-Login
     @login_manager.user_loader
     def load_user(user_id):
         from app.models.user import User
         return User.query.get(user_id)
-    
+
+    app.logger.info('Application startup')
+
     return app

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,6 @@
 from flask import request, send_file, abort, jsonify
 from flask_restx import Resource
+import logging
 
 from app.api import api
 from app import db
@@ -42,6 +43,7 @@ class AthleteList(Resource):
         )
         db.session.add(athlete)
         db.session.commit()
+        logging.getLogger(__name__).info("Created athlete %s", athlete.id)
         return jsonify(athlete.to_dict()), 201
 
 
@@ -63,6 +65,7 @@ class AthleteResource(Resource):
             if field in data:
                 setattr(athlete, field, data[field])
         db.session.commit()
+        logging.getLogger(__name__).info("Updated athlete %s", athlete.id)
         return jsonify(athlete.to_dict())
 
     @api.doc(description="Delete an athlete")
@@ -70,6 +73,7 @@ class AthleteResource(Resource):
         athlete = AthleteProfile.query.get_or_404(athlete_id)
         athlete.is_deleted = True
         db.session.commit()
+        logging.getLogger(__name__).info("Deleted athlete %s", athlete.id)
         return '', 204
 
 
@@ -100,6 +104,7 @@ class AthleteMediaList(Resource):
         )
         db.session.add(media)
         db.session.commit()
+        logging.getLogger(__name__).info("Uploaded media %s", media.id)
         return jsonify(media.to_dict()), 201
 
 
@@ -114,6 +119,7 @@ class MediaResource(Resource):
         MediaService.delete_file(media.file_path)
         db.session.delete(media)
         db.session.commit()
+        logging.getLogger(__name__).info("Deleted media %s", media.id)
         return '', 204
 
 
@@ -153,6 +159,7 @@ class AthleteStats(Resource):
             stat = AthleteStat(athlete_id=athlete_id, name=name, value=data.get('value'))
             db.session.add(stat)
         db.session.commit()
+        logging.getLogger(__name__).info("Updated stat %s for athlete %s", name, athlete_id)
         return jsonify(stat.to_dict())
 
 
@@ -166,12 +173,14 @@ class StatResource(Resource):
         stat = AthleteStat.query.get_or_404(stat_id)
         db.session.delete(stat)
         db.session.commit()
+        logging.getLogger(__name__).info("Deleted stat %s", stat_id)
         return '', 204
       
 @bp.route('/athletes', methods=['POST'])
 def create_athlete():
     data = request.get_json() or {}
     athlete = create_athlete_service(data)
+    logging.getLogger(__name__).info("Created athlete %s", athlete.id)
     return jsonify(athlete.to_dict()), 201
 
 @bp.route('/athletes/<athlete_id>', methods=['GET'])
@@ -183,11 +192,13 @@ def get_athlete(athlete_id):
 def update_athlete(athlete_id):
     data = request.get_json() or {}
     athlete = update_athlete_service(athlete_id, data)
+    logging.getLogger(__name__).info("Updated athlete %s", athlete.id)
     return jsonify(athlete.to_dict())
 
 @bp.route('/athletes/<athlete_id>', methods=['DELETE'])
 def delete_athlete(athlete_id):
     delete_athlete_service(athlete_id)
+    logging.getLogger(__name__).info("Deleted athlete %s", athlete_id)
     return '', 204
 
 @bp.route('/athletes', methods=['GET'])
@@ -215,6 +226,7 @@ def upload_media(athlete_id):
     )
     db.session.add(media)
     db.session.commit()
+    logging.getLogger(__name__).info("Uploaded media %s", media.id)
     return jsonify(media.to_dict()), 201
 
 @bp.route('/athletes/<athlete_id>/media', methods=['GET'])
@@ -229,6 +241,7 @@ def delete_media(media_id):
     MediaService.delete_file(media.file_path)
     db.session.delete(media)
     db.session.commit()
+    logging.getLogger(__name__).info("Deleted media %s", media.id)
     return '', 204
 
 @bp.route('/media/<media_id>/download', methods=['GET'])
@@ -251,6 +264,7 @@ def add_or_update_stat(athlete_id):
         stat = AthleteStat(athlete_id=athlete_id, name=name, value=data.get('value'))
         db.session.add(stat)
     db.session.commit()
+    logging.getLogger(__name__).info("Updated stat %s for athlete %s", name, athlete_id)
     return jsonify(stat.to_dict())
 
 @bp.route('/athletes/<athlete_id>/stats', methods=['GET'])
@@ -264,5 +278,6 @@ def delete_stat(stat_id):
     stat = AthleteStat.query.get_or_404(stat_id)
     db.session.delete(stat)
     db.session.commit()
+    logging.getLogger(__name__).info("Deleted stat %s", stat_id)
     return '', 204
 

--- a/app/services/media_service.py
+++ b/app/services/media_service.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import logging
 from werkzeug.utils import secure_filename
 
 class MediaService:
@@ -17,11 +18,13 @@ class MediaService:
         filename = f"{uuid.uuid4().hex}{ext}"
         path = os.path.join(directory, secure_filename(filename))
         file_storage.save(path)
+        logging.getLogger(__name__).info("Saved media file %s", path)
         return path, filename
 
     @staticmethod
     def delete_file(path):
         try:
             os.remove(path)
+            logging.getLogger(__name__).info("Deleted media file %s", path)
         except FileNotFoundError:
             pass


### PR DESCRIPTION
## Summary
- wire up RotatingFileHandler in `create_app`
- emit log statements from MediaService and API routes
- document log file location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ddb5231f08327bb8efed4f585bada