### PR TITLE
Add React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,4 +191,5 @@ cython_debug/
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
-.cursorindexingignore
+.cursorindexingignore\n# Node modules\nnode_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Query parameters:
 - `min_weight` / `max_weight` – filter by weight in kilograms
 
 The endpoint returns a JSON object containing the matched athletes ordered by overall rating.
+
+## Frontend Development
+
+See `frontend/README.md` for running the React development server.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,20 @@
+# Frontend
+
+This directory contains the React application built with Vite. The app connects to the Flask API in the repository root.
+
+## Development server
+
+Install dependencies once using npm (or yarn):
+
+```bash
+cd frontend
+npm install
+```
+
+Then start the Vite development server:
+
+```bash
+npm run dev
+```
+
+The server proxies API requests to `http://localhost:5000` so make sure the Flask backend is running locally on port 5000.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pro Sports Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,17 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import AthleteList from './components/AthleteList';
+import AthleteProfile from './views/AthleteProfile';
+
+export default function App() {
+  return (
+    <div>
+      <nav>
+        <Link to="/">Home</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<AthleteList />} />
+        <Route path="/athletes/:id" element={<AthleteProfile />} />
+      </Routes>
+    </div>
+  );
+}

--- a/frontend/src/components/AthleteList.jsx
+++ b/frontend/src/components/AthleteList.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function AthleteList() {
+  const [athletes, setAthletes] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/athletes')
+      .then((res) => res.json())
+      .then((data) => setAthletes(data.items || []))
+      .catch((err) => console.error('Failed to fetch athletes', err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Athletes</h1>
+      <ul>
+        {athletes.map((a) => (
+          <li key={a.athlete_id}>
+            <Link to={`/athletes/${a.athlete_id}`}>{a.user.full_name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/views/AthleteProfile.jsx
+++ b/frontend/src/views/AthleteProfile.jsx
@@ -1,0 +1,26 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+export default function AthleteProfile() {
+  const { id } = useParams();
+  const [athlete, setAthlete] = useState(null);
+
+  useEffect(() => {
+    fetch(`/api/athletes/${id}`)
+      .then((res) => res.json())
+      .then((data) => setAthlete(data))
+      .catch((err) => console.error('Failed to fetch athlete', err));
+  }, [id]);
+
+  if (!athlete) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>{athlete.user.full_name}</h2>
+      <p>{athlete.bio}</p>
+      <p>Date of Birth: {athlete.date_of_birth}</p>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite-based React app in `frontend/`
- show athlete list and profile screens with API calls
- document how to start the development server
- update `.gitignore` for node artifacts

## Testing
- `pytest -q` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_685ddb5359d483279b01038bf2aad748