### PR TITLE
Fix blueprint import for API routes

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -3,7 +3,7 @@ from app.utils.validators import validate_json, validate_params
 from flask_restx import Resource
 import logging
 
-from app.api import api
+from app.api import api, bp
 from app import db
 from app.models import AthleteProfile, AthleteMedia, AthleteStat
 from app.services.media_service import MediaService


### PR DESCRIPTION
## Summary
- import `bp` along with `api` in `app/api/routes.py`

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'UserStatus')*
- `python run.py` *(fails: ImportError cannot import name 'UserStatus')*

------
https://chatgpt.com/codex/tasks/task_e_685df8800a348327833e14cd6f6ddca4