### PR TITLE
Fix database password in Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ load_dotenv(os.path.join(basedir, '.env'))
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-change-me'
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'postgresql://postgres:Kafka%40221K@localhost:5432/sport_agency_dev'
+        'postgresql://postgres:postgres@localhost:5432/sport_agency_dev'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     
     # Session Configuration


### PR DESCRIPTION
## Summary
- update hard-coded DB password

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'UserStatus' from 'app.models')*

------
https://chatgpt.com/codex/tasks/task_e_685df88909348327b136557237ac09e6