### PR TITLE
Add media upload via drag-and-drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore\n# Node modules\nnode_modules/
 frontend/dist/
+storage/

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -34,3 +34,6 @@ body {
 }
 /* Media upload styles */
 #drop-area.dragover { background-color: #f0f0f0; }
+#upload-progress {
+    height: 1rem;
+}

--- a/static/js/media_upload.js
+++ b/static/js/media_upload.js
@@ -12,7 +12,58 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     dropArea.classList.remove('dragover');
     const files = e.dataTransfer.files;
-    // TODO: implement upload logic
-    alert(`${files.length} file(s) dropped`);
+    if (!files.length) return;
+    const progress = document.getElementById('upload-progress');
+    const progressBar = progress ? progress.querySelector('.progress-bar') : null;
+    const messageEl = document.getElementById('upload-message');
+    const athleteId = dropArea.dataset.athleteId;
+
+    const uploadFile = (file) => {
+      return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', `/api/athletes/${athleteId}/media`);
+
+        xhr.upload.addEventListener('progress', (ev) => {
+          if (ev.lengthComputable && progressBar) {
+            const pct = (ev.loaded / ev.total) * 100;
+            progressBar.style.width = pct + '%';
+          }
+        });
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve();
+          } else {
+            reject(new Error('Upload failed'));
+          }
+        };
+        xhr.onerror = () => reject(new Error('Upload failed'));
+
+        const formData = new FormData();
+        formData.append('file', file);
+        xhr.send(formData);
+      });
+    };
+
+    const run = async () => {
+      for (const file of files) {
+        if (progress && progressBar) {
+          progress.classList.remove('d-none');
+          progressBar.style.width = '0%';
+        }
+        if (messageEl) messageEl.textContent = `Uploading ${file.name}...`;
+        try {
+          await uploadFile(file);
+          if (messageEl) messageEl.textContent = `${file.name} uploaded successfully.`;
+        } catch (err) {
+          if (messageEl) messageEl.textContent = `Error uploading ${file.name}`;
+        }
+      }
+      setTimeout(() => {
+        if (progress) progress.classList.add('d-none');
+      }, 1000);
+    };
+
+    run();
   });
 });

--- a/templates/athletes/media_gallery.html
+++ b/templates/athletes/media_gallery.html
@@ -1,4 +1,8 @@
-<div id="drop-area" class="border border-secondary p-5 text-center rounded">
+<div id="drop-area" class="border border-secondary p-5 text-center rounded" data-athlete-id="{{ athlete.athlete_id }}">
   <p class="mb-0">Drag and drop media files here</p>
 </div>
+<div id="upload-progress" class="progress mt-3 d-none">
+  <div class="progress-bar" role="progressbar" style="width: 0%"></div>
+</div>
+<div id="upload-message" class="mt-2"></div>
 <script src="{{ url_for('static', filename='js/media_upload.js') }}"></script>


### PR DESCRIPTION
## Summary
- implement AJAX upload logic in `media_upload.js`
- expose athlete id and progress bar in `media_gallery.html`
- style upload progress bar
- ignore local storage folder

## Testing
- `pytest -q` *(fails: create_app errors)*

------
https://chatgpt.com/codex/tasks/task_e_685df894e9448327829d5b089f980ed5