### PR TITLE
Add maintenance scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,21 @@ Application logs are written to `logs/app.log` inside the project directory.
 
 Application code is mounted into the container for live reloading during development.
 
+
+## Maintenance Scripts
+
+The `scripts` directory contains simple utilities for working with the project.
+
+### backup_db.sh
+Dumps the PostgreSQL database defined in `DATABASE_URL` to a timestamped file. A backup directory may be supplied as the first argument (defaults to `backups`).
+
+```bash
+DATABASE_URL=postgresql://user:pass@host/dbname bash scripts/backup_db.sh [backup_dir]
+```
+
+### check_storage.py
+Checks that a path exists and has at least the specified free space in megabytes (defaults to `100` MB).
+
+```bash
+python scripts/check_storage.py /path/to/dir [required_mb]
+```

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+BACKUP_DIR=${1:-backups}
+mkdir -p "$BACKUP_DIR"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_FILE="$BACKUP_DIR/db_backup_${TIMESTAMP}.sql"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL environment variable is not set" >&2
+  exit 1
+fi
+
+pg_dump "$DATABASE_URL" > "$BACKUP_FILE"
+echo "Database backed up to $BACKUP_FILE"

--- a/scripts/check_storage.py
+++ b/scripts/check_storage.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import sys
+
+
+def check_storage(path: str, required_mb: int = 100) -> int:
+    if not os.path.exists(path):
+        print(f"Path {path} does not exist", file=sys.stderr)
+        return 1
+
+    total, used, free = shutil.disk_usage(path)
+    free_mb = free / (1024 * 1024)
+
+    if free_mb < required_mb:
+        print(
+            f"Insufficient space in {path}: {free_mb:.2f} MB free, "
+            f"{required_mb} MB required",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{path} has sufficient space: {free_mb:.2f} MB free")
+    return 0
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "."
+    required = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+    sys.exit(check_storage(path, required))


### PR DESCRIPTION
## Summary
- add `scripts/backup_db.sh` for backing up the database
- add `scripts/check_storage.py` for verifying disk space
- document the new scripts in the README

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'UserStatus' from 'app.models')*

------
https://chatgpt.com/codex/tasks/task_e_685df89580448327b9b2125b0d7cf497