### PR TITLE
Add AthleteSkill model and seed data

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,8 +2,13 @@ from .user import User
 from .role import Role, UserRole
 from .oauth import UserOAuthAccount
 from .sport import Sport, Position
+from .athlete import AthleteProfile
+from .media import AthleteMedia
+from .stats import AthleteStat
+from .skill import AthleteSkill
 
 __all__ = [
-    'User', 'Role', 'UserRole', 
-    'UserOAuthAccount', 'Sport', 'Position'
+    'User', 'Role', 'UserRole',
+    'UserOAuthAccount', 'Sport', 'Position',
+    'AthleteProfile', 'AthleteMedia', 'AthleteStat', 'AthleteSkill'
 ]

--- a/app/models/athlete.py
+++ b/app/models/athlete.py
@@ -48,6 +48,7 @@ class AthleteProfile(BaseModel):
     user = db.relationship('User', back_populates='athlete_profile')
     primary_sport = db.relationship('Sport', back_populates='athletes')
     primary_position = db.relationship('Position')
+    skills = db.relationship('AthleteSkill', back_populates='athlete', cascade='all, delete-orphan')
     
     # Constraints
     __table_args__ = (

--- a/app/models/skill.py
+++ b/app/models/skill.py
@@ -1,0 +1,21 @@
+from app import db
+from app.models.base import BaseModel
+import uuid
+
+class AthleteSkill(BaseModel):
+    __tablename__ = 'athlete_skills'
+
+    skill_id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    athlete_id = db.Column(db.String(36), db.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    level = db.Column(db.Integer)
+
+    athlete = db.relationship('AthleteProfile', back_populates='skills')
+
+    __table_args__ = (
+        db.Index('idx_skills_athlete', 'athlete_id'),
+    )
+
+    def __repr__(self):
+        return f'<AthleteSkill {self.skill_id}>'
+

--- a/migrations/versions/cbacbef4e34e_add_athlete_skills.py
+++ b/migrations/versions/cbacbef4e34e_add_athlete_skills.py
@@ -1,0 +1,34 @@
+"""add athlete skills table
+
+Revision ID: cbacbef4e34e
+Revises: 5bb8dbba77e3
+Create Date: 2025-06-16 15:40:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'cbacbef4e34e'
+down_revision = '5bb8dbba77e3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'athlete_skills',
+        sa.Column('skill_id', sa.String(length=36), primary_key=True),
+        sa.Column('athlete_id', sa.String(length=36), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('level', sa.Integer()),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['athlete_id'], ['athlete_profiles.athlete_id'], ondelete='CASCADE'),
+    )
+    op.create_index('idx_skills_athlete', 'athlete_skills', ['athlete_id'])
+
+
+def downgrade():
+    op.drop_index('idx_skills_athlete', table_name='athlete_skills')
+    op.drop_table('athlete_skills')
+

--- a/run.py
+++ b/run.py
@@ -1,8 +1,18 @@
 import os
 from app import create_app, db
-from app.models import User, Role, UserRole, UserOAuthAccount, Sport, Position
+from app.models import (
+    User,
+    Role,
+    UserRole,
+    UserOAuthAccount,
+    Sport,
+    Position,
+    AthleteProfile,
+    AthleteSkill,
+)
 from flask.cli import with_appcontext
 import click
+from datetime import date
 
 app = create_app(os.getenv('FLASK_ENV') or 'development')
 
@@ -15,7 +25,9 @@ def make_shell_context():
         'UserRole': UserRole,
         'UserOAuthAccount': UserOAuthAccount,
         'Sport': Sport,
-        'Position': Position
+        'Position': Position,
+        'AthleteProfile': AthleteProfile,
+        'AthleteSkill': AthleteSkill
     }
 
 @app.cli.command()
@@ -116,9 +128,37 @@ def init_db():
                     description=pos_data['description']
                 )
                 db.session.add(position)
-    
+
+    # Commit roles, sports and positions
     db.session.commit()
-    click.echo('Database initialized with default roles and sports.')
+
+    # Sample athlete with skills
+    if not User.query.filter_by(username='sampleathlete').first():
+        user = User(
+            username='sampleathlete',
+            email='sample@example.com',
+            first_name='Sample',
+            last_name='Athlete'
+        )
+        user.set_password('password')
+        db.session.add(user)
+        db.session.flush()
+
+        profile = AthleteProfile(
+            user_id=user.user_id,
+            date_of_birth=date(1990, 1, 1)
+        )
+        db.session.add(profile)
+        db.session.flush()
+
+        skills = [
+            AthleteSkill(athlete_id=profile.athlete_id, name='Speed', level=5),
+            AthleteSkill(athlete_id=profile.athlete_id, name='Agility', level=4),
+        ]
+        db.session.add_all(skills)
+
+    db.session.commit()
+    click.echo('Database initialized with default roles, sports and sample athlete.')
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- define `AthleteSkill` model
- expose new model from `app.models`
- link `AthleteProfile.skills` relationship
- add Alembic migration for `athlete_skills`
- seed a sample athlete with skills in `init_db`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ee31268548327941814e331fde4dc