### PR TITLE
Add athlete skill API endpoints

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -15,4 +15,4 @@ api = Api(
 )
 
 # Import resources to register endpoints with this Api
-from app.api import routes, athletes  # noqa: E402
+from app.api import routes, athletes, skills  # noqa: E402

--- a/app/api/skills.py
+++ b/app/api/skills.py
@@ -1,0 +1,61 @@
+from flask import request, jsonify
+from flask_restx import Resource
+import logging
+
+from app.api import api
+from app import db
+from app.models import AthleteProfile, AthleteSkill
+from app.utils.validators import validate_json
+
+
+@api.route('/athletes/<string:athlete_id>/skills')
+@api.param('athlete_id', 'Athlete identifier')
+class AthleteSkillList(Resource):
+    """List or create athlete skills."""
+
+    @api.doc(description="List skills for an athlete")
+    def get(self, athlete_id):
+        AthleteProfile.query.filter_by(athlete_id=athlete_id, is_deleted=False).first_or_404()
+        skills = AthleteSkill.query.filter_by(athlete_id=athlete_id).all()
+        return jsonify([s.to_dict() for s in skills])
+
+    @api.doc(description="Create a new skill", params={'name': 'Skill name', 'level': 'Skill level'})
+    @validate_json(['name'])
+    def post(self, athlete_id):
+        AthleteProfile.query.filter_by(athlete_id=athlete_id, is_deleted=False).first_or_404()
+        data = request.get_json() or {}
+        skill = AthleteSkill(
+            athlete_id=athlete_id,
+            name=data.get('name'),
+            level=data.get('level'),
+        )
+        db.session.add(skill)
+        db.session.commit()
+        logging.getLogger(__name__).info("Created skill %s for athlete %s", skill.skill_id, athlete_id)
+        return jsonify(skill.to_dict()), 201
+
+
+@api.route('/skills/<string:skill_id>')
+@api.param('skill_id', 'Skill identifier')
+class SkillResource(Resource):
+    """Update or delete a skill."""
+
+    @api.doc(description="Update a skill")
+    @validate_json([])
+    def put(self, skill_id):
+        skill = AthleteSkill.query.get_or_404(skill_id)
+        data = request.get_json() or {}
+        for field in ['name', 'level']:
+            if field in data:
+                setattr(skill, field, data[field])
+        db.session.commit()
+        logging.getLogger(__name__).info("Updated skill %s", skill_id)
+        return jsonify(skill.to_dict())
+
+    @api.doc(description="Delete a skill")
+    def delete(self, skill_id):
+        skill = AthleteSkill.query.get_or_404(skill_id)
+        db.session.delete(skill)
+        db.session.commit()
+        logging.getLogger(__name__).info("Deleted skill %s", skill_id)
+        return '', 204

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,3 +48,45 @@ def test_404_returns_json(client):
     assert resp.status_code == 404
     data = json.loads(resp.data)
     assert 'error' in data or 'message' in data
+
+
+def _create_athlete():
+    user = User(username='u_skill', email='skill@example.com', first_name='S', last_name='Kill')
+    user.save()
+    athlete = AthleteProfile(user_id=user.user_id, date_of_birth=date.fromisoformat('2000-01-01'))
+    athlete.save()
+    return athlete
+
+
+def test_skill_crud(client):
+    athlete = _create_athlete()
+
+    resp = client.post(
+        f'/api/athletes/{athlete.athlete_id}/skills',
+        json={'name': 'Speed', 'level': 5}
+    )
+    assert resp.status_code == 201
+    skill = json.loads(resp.data)
+
+    resp = client.get(f'/api/athletes/{athlete.athlete_id}/skills')
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data) == 1
+
+    resp = client.put(f"/api/skills/{skill['skill_id']}", json={'level': 7})
+    assert resp.status_code == 200
+    updated = json.loads(resp.data)
+    assert updated['level'] == 7
+
+    resp = client.delete(f"/api/skills/{skill['skill_id']}")
+    assert resp.status_code == 204
+
+    resp = client.get(f'/api/athletes/{athlete.athlete_id}/skills')
+    data = json.loads(resp.data)
+    assert data == []
+
+
+def test_create_skill_missing_name(client):
+    athlete = _create_athlete()
+    resp = client.post(f'/api/athletes/{athlete.athlete_id}/skills', json={})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement CRUD routes for `AthleteSkill`
- register the new routes in API blueprint
- test athlete skill endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ee718466083278a954273c7998723