### PR TITLE
Add testing configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,8 +25,13 @@ class DevelopmentConfig(Config):
 class ProductionConfig(Config):
     DEBUG = False
 
+class TestingConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///:memory:'
+
 config = {
     'development': DevelopmentConfig,
     'production': ProductionConfig,
+    'testing': TestingConfig,
     'default': DevelopmentConfig
 }


### PR DESCRIPTION
## Summary
- add `TestingConfig` using an in-memory SQLite database for tests
- register `'testing'` in the config map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0f470f4832799e70941cba240f9