### PR TITLE
Add athlete form and editing UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Link } from 'react-router-dom';
 import AthleteList from './components/AthleteList';
 import AthleteProfile from './views/AthleteProfile';
+import AthleteForm from './components/AthleteForm';
 
 export default function App() {
   return (
@@ -10,6 +11,8 @@ export default function App() {
       </nav>
       <Routes>
         <Route path="/" element={<AthleteList />} />
+        <Route path="/athletes/new" element={<AthleteForm />} />
+        <Route path="/athletes/:id/edit" element={<AthleteForm />} />
         <Route path="/athletes/:id" element={<AthleteProfile />} />
       </Routes>
     </div>

--- a/frontend/src/components/AthleteForm.jsx
+++ b/frontend/src/components/AthleteForm.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export default function AthleteForm() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEdit = Boolean(id);
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [dob, setDob] = useState('');
+  const [nationality, setNationality] = useState('');
+
+  useEffect(() => {
+    if (isEdit) {
+      fetch(`/api/athletes/${id}`)
+        .then((res) => res.json())
+        .then((data) => {
+          setFirstName(data.user.first_name || '');
+          setLastName(data.user.last_name || '');
+          setDob(data.date_of_birth || '');
+          setNationality(data.nationality || '');
+        })
+        .catch((err) => console.error('Failed to fetch athlete', err));
+    }
+  }, [isEdit, id]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const payload = {
+      first_name: firstName,
+      last_name: lastName,
+      date_of_birth: dob,
+      nationality,
+    };
+    const url = isEdit ? `/api/athletes/${id}` : '/api/athletes';
+    const method = isEdit ? 'PUT' : 'POST';
+    fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        const athleteId = data.athlete_id || id;
+        navigate(`/athletes/${athleteId}`);
+      })
+      .catch((err) => console.error('Failed to save athlete', err));
+  };
+
+  return (
+    <div className="container">
+      <h2>{isEdit ? 'Edit Athlete' : 'New Athlete'}</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="form-row">
+          <label>First Name</label>
+          <input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+        </div>
+        <div className="form-row">
+          <label>Last Name</label>
+          <input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+        </div>
+        <div className="form-row">
+          <label>Date of Birth</label>
+          <input type="date" value={dob} onChange={(e) => setDob(e.target.value)} />
+        </div>
+        <div className="form-row">
+          <label>Nationality</label>
+          <input value={nationality} onChange={(e) => setNationality(e.target.value)} />
+        </div>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/AthleteList.jsx
+++ b/frontend/src/components/AthleteList.jsx
@@ -7,6 +7,9 @@ export default function AthleteList() {
   const [sport, setSport] = useState('');
   const [minAge, setMinAge] = useState('');
   const [maxAge, setMaxAge] = useState('');
+  const [name, setName] = useState('');
+  const [position, setPosition] = useState('');
+  const [team, setTeam] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -19,6 +22,9 @@ export default function AthleteList() {
     if (sport) params.append('sport', sport);
     if (minAge) params.append('min_age', minAge);
     if (maxAge) params.append('max_age', maxAge);
+    if (name) params.append('name', name);
+    if (position) params.append('position', position);
+    if (team) params.append('team', team);
 
     fetch(`/api/athletes/search?${params.toString()}`)
       .then((res) => {
@@ -46,6 +52,24 @@ export default function AthleteList() {
           placeholder="Search..."
           value={q}
           onChange={(e) => setQ(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Position"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Team"
+          value={team}
+          onChange={(e) => setTeam(e.target.value)}
         />
         <input
           type="text"

--- a/frontend/src/components/SkillEditor.jsx
+++ b/frontend/src/components/SkillEditor.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+
+export default function SkillEditor({ athleteId }) {
+  const [skills, setSkills] = useState([]);
+  const [name, setName] = useState('');
+  const [level, setLevel] = useState('');
+
+  const load = () => {
+    fetch(`/api/athletes/${athleteId}/skills`)
+      .then((res) => res.json())
+      .then(setSkills)
+      .catch((err) => console.error('Failed to load skills', err));
+  };
+
+  useEffect(() => {
+    if (athleteId) load();
+  }, [athleteId]);
+
+  const addSkill = () => {
+    fetch(`/api/athletes/${athleteId}/skills`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, level: level ? Number(level) : undefined }),
+    })
+      .then((res) => res.json())
+      .then((s) => {
+        setSkills([...skills, s]);
+        setName('');
+        setLevel('');
+      })
+      .catch((err) => console.error('Failed to add skill', err));
+  };
+
+  const updateSkill = (skillId, newLevel) => {
+    fetch(`/api/skills/${skillId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level: newLevel }),
+    })
+      .then((res) => res.json())
+      .then((updated) => {
+        setSkills(skills.map((s) => (s.skill_id === skillId ? updated : s)));
+      })
+      .catch((err) => console.error('Failed to update skill', err));
+  };
+
+  const deleteSkill = (skillId) => {
+    fetch(`/api/skills/${skillId}`, { method: 'DELETE' })
+      .then(() => setSkills(skills.filter((s) => s.skill_id !== skillId)))
+      .catch((err) => console.error('Failed to delete skill', err));
+  };
+
+  return (
+    <div>
+      <h3>Skills</h3>
+      <ul className="skill-list">
+        {skills.map((s) => (
+          <li key={s.skill_id}>
+            <span>{s.name}</span>
+            <input
+              type="number"
+              value={s.level || ''}
+              onChange={(e) => updateSkill(s.skill_id, Number(e.target.value))}
+              style={{ width: '60px', marginLeft: '0.5rem' }}
+            />
+            <button onClick={() => deleteSkill(s.skill_id)}>x</button>
+          </li>
+        ))}
+      </ul>
+      <div className="form-row">
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="Level"
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+          style={{ width: '80px' }}
+        />
+        <button type="button" onClick={addSkill}>
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StatEditor.jsx
+++ b/frontend/src/components/StatEditor.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+
+export default function StatEditor({ athleteId }) {
+  const [stats, setStats] = useState([]);
+  const [name, setName] = useState('');
+  const [value, setValue] = useState('');
+  const [season, setSeason] = useState('');
+
+  const load = () => {
+    fetch(`/api/athletes/${athleteId}/stats`)
+      .then((res) => res.json())
+      .then(setStats)
+      .catch((err) => console.error('Failed to load stats', err));
+  };
+
+  useEffect(() => {
+    if (athleteId) load();
+  }, [athleteId]);
+
+  const addStat = () => {
+    fetch(`/api/athletes/${athleteId}/stats`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, value, season }),
+    })
+      .then((res) => res.json())
+      .then((s) => {
+        setStats([...stats, s]);
+        setName('');
+        setValue('');
+        setSeason('');
+      })
+      .catch((err) => console.error('Failed to add stat', err));
+  };
+
+  const deleteStat = (statId) => {
+    fetch(`/api/stats/${statId}`, { method: 'DELETE' })
+      .then(() => setStats(stats.filter((s) => s.stat_id !== statId)))
+      .catch((err) => console.error('Failed to delete stat', err));
+  };
+
+  return (
+    <div>
+      <h3>Stats</h3>
+      <ul className="stat-list">
+        {stats.map((s) => (
+          <li key={s.stat_id}>
+            <span>
+              {s.name} {s.season && `(${s.season})`} : {s.value}
+            </span>
+            <button onClick={() => deleteStat(s.stat_id)}>x</button>
+          </li>
+        ))}
+      </ul>
+      <div className="form-row">
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          placeholder="Value"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <input
+          placeholder="Season"
+          value={season}
+          onChange={(e) => setSeason(e.target.value)}
+          style={{ width: '80px' }}
+        />
+        <button type="button" onClick={addStat}>
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,49 @@ body {
   margin: 0;
   padding: 0;
 }
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+  align-items: center;
+}
+
+.form-row label {
+  flex: 1 0 150px;
+}
+
+.form-row input {
+  flex: 2 0 200px;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .form-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .form-row label {
+    margin-bottom: 0.25rem;
+  }
+}
+
+.skill-list,
+.stat-list {
+  list-style: none;
+  padding: 0;
+}
+
+.skill-list li,
+.stat-list li {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/views/AthleteProfile.jsx
+++ b/frontend/src/views/AthleteProfile.jsx
@@ -1,8 +1,11 @@
-import { useParams } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import SkillEditor from '../components/SkillEditor';
+import StatEditor from '../components/StatEditor';
 
 export default function AthleteProfile() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [athlete, setAthlete] = useState(null);
 
   useEffect(() => {
@@ -12,15 +15,32 @@ export default function AthleteProfile() {
       .catch((err) => console.error('Failed to fetch athlete', err));
   }, [id]);
 
+  const handleDelete = () => {
+    if (!window.confirm('Delete this athlete?')) return;
+    fetch(`/api/athletes/${id}`, { method: 'DELETE' })
+      .then((res) => {
+        if (res.ok) navigate('/');
+      })
+      .catch((err) => console.error('Failed to delete athlete', err));
+  };
+
   if (!athlete) {
     return <div>Loading...</div>;
   }
 
   return (
-    <div>
+    <div className="container">
       <h2>{athlete.user.full_name}</h2>
       <p>{athlete.bio}</p>
       <p>Date of Birth: {athlete.date_of_birth}</p>
+      <div className="form-row">
+        <Link to={`/athletes/${id}/edit`}>Edit</Link>
+        <button onClick={handleDelete} style={{ marginLeft: '1rem' }}>
+          Delete
+        </button>
+      </div>
+      <SkillEditor athleteId={id} />
+      <StatEditor athleteId={id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create React forms to add/edit athletes
- create inline editors for skills and stats
- add delete action to athlete profile
- allow searching athletes by more fields
- style pages responsively

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0f67a3083279e2f9767f642e37f