### PR TITLE
Add position and team search filters

### DIFF
--- a/app/api/athletes.py
+++ b/app/api/athletes.py
@@ -24,6 +24,8 @@ def _cached_search(key):
     params = dict(item.split('=', 1) for item in key.split('&') if '=' in item)
     q = params.get('q', '')
     sport = params.get('sport')
+    position = params.get('position')
+    team = params.get('team')
     min_age = int(params['min_age']) if 'min_age' in params else None
     max_age = int(params['max_age']) if 'max_age' in params else None
     min_height = int(params['min_height']) if 'min_height' in params else None
@@ -43,6 +45,20 @@ def _cached_search(key):
             query = query.filter(AthleteProfile.primary_sport_id == int(sport))
         else:
             query = query.filter(Sport.code.ilike(sport))
+
+    if position:
+        if position.isdigit():
+            query = query.filter(
+                AthleteProfile.primary_position_id == int(position)
+            )
+        else:
+            pattern = f"%{position}%"
+            query = query.filter(
+                or_(Position.code.ilike(position), Position.name.ilike(pattern))
+            )
+
+    if team:
+        query = query.filter(AthleteProfile.current_team.ilike(f"%{team}%"))
 
     if q:
         pattern = f"%{q}%"
@@ -89,6 +105,8 @@ class AthleteSearch(Resource):
     @api.doc(params={
         'q': 'Free text search',
         'sport': 'Sport code or id',
+        'position': 'Position code or id',
+        'team': 'Current team name',
         'min_age': 'Minimum age',
         'max_age': 'Maximum age',
         'min_height': 'Minimum height (cm)',

--- a/frontend/src/components/AthleteList.jsx
+++ b/frontend/src/components/AthleteList.jsx
@@ -5,6 +5,8 @@ export default function AthleteList() {
   const [athletes, setAthletes] = useState([]);
   const [q, setQ] = useState('');
   const [sport, setSport] = useState('');
+  const [position, setPosition] = useState('');
+  const [team, setTeam] = useState('');
   const [minAge, setMinAge] = useState('');
   const [maxAge, setMaxAge] = useState('');
   const [loading, setLoading] = useState(false);
@@ -17,6 +19,8 @@ export default function AthleteList() {
     const params = new URLSearchParams();
     if (q) params.append('q', q);
     if (sport) params.append('sport', sport);
+    if (position) params.append('position', position);
+    if (team) params.append('team', team);
     if (minAge) params.append('min_age', minAge);
     if (maxAge) params.append('max_age', maxAge);
 
@@ -52,6 +56,18 @@ export default function AthleteList() {
           placeholder="Sport"
           value={sport}
           onChange={(e) => setSport(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Position"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Team"
+          value={team}
+          onChange={(e) => setTeam(e.target.value)}
         />
         <input
           type="number"


### PR DESCRIPTION
## Summary
- extend athlete search API with position and team filters
- expose new search fields in React athlete list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0f8d5708327a09afe604764fbc7