### PR TITLE
Fix duplicate shell context key

### DIFF
--- a/run.py
+++ b/run.py
@@ -30,7 +30,6 @@ def make_shell_context():
         'AthleteProfile': AthleteProfile,
         'AthleteSkill': AthleteSkill,
         'AthleteStat': AthleteStat,
-        'AthleteSkill': AthleteSkill
     }
 
 @app.cli.command()


### PR DESCRIPTION
## Summary
- remove duplicate `AthleteSkill` entry in `make_shell_context`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ef60e8d9483278bc8bb3db3b04a01