### PR TITLE
Add Playwright e2e test

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,3 +18,23 @@ npm run dev
 ```
 
 The server proxies API requests to `http://localhost:5000` so make sure the Flask backend is running locally on port 5000.
+
+## End-to-end tests
+
+Playwright tests are located in the `tests` directory. They spin up the Flask
+application in testing mode and drive a headless browser to create and edit an
+athlete profile.
+
+To run them:
+
+```bash
+# Install Python dependencies
+pip install -r ../requirements.txt
+# Install browser binaries
+playwright install
+# Execute tests
+pytest tests/test_playwright_e2e.py
+```
+
+The server is started automatically by the test suite, so no additional setup is
+required.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ typing_extensions==4.14.0
 urllib3==2.4.0
 Werkzeug==3.1.3
 WTForms==3.0.1
+playwright==1.42.0

--- a/tests/test_playwright_e2e.py
+++ b/tests/test_playwright_e2e.py
@@ -1,0 +1,57 @@
+import threading
+import time
+
+import pytest
+from werkzeug.serving import make_server
+from playwright.sync_api import sync_playwright
+
+from app import create_app, db
+from app.models import AthleteProfile
+
+
+@pytest.fixture(scope="module")
+def flask_app():
+    app = create_app('testing')
+    app.config['LOGIN_DISABLED'] = True
+    with app.app_context():
+        db.create_all()
+    server = make_server('127.0.0.1', 5000, app)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    time.sleep(1)
+    yield app
+    server.shutdown()
+    thread.join()
+    with app.app_context():
+        db.drop_all()
+
+
+def test_create_and_edit_profile(flask_app):
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+
+        page.goto('http://localhost:5000/athletes/new')
+        page.fill('input#first_name', 'E2E')
+        page.fill('input#last_name', 'Tester')
+        page.fill('input#date_of_birth', '2000-01-01')
+        page.fill('input#nationality', 'USA')
+        page.click('input[type=submit]')
+        page.wait_for_url('**/athletes/*')
+        athlete_id = page.url.rsplit('/', 1)[-1]
+
+        with flask_app.app_context():
+            athlete = AthleteProfile.query.get(athlete_id)
+            assert athlete is not None
+            assert athlete.user.first_name == 'E2E'
+
+        page.click('text=Edit')
+        page.fill('input#first_name', 'Updated')
+        page.click('input[type=submit]')
+        page.wait_for_url(f'**/athletes/{athlete_id}')
+
+        with flask_app.app_context():
+            athlete = AthleteProfile.query.get(athlete_id)
+            assert athlete.user.first_name == 'Updated'
+
+        browser.close()


### PR DESCRIPTION
## Summary
- add Playwright-based E2E test that fills the athlete form
- document how to run Playwright tests
- include Playwright in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f052abce48327859661a4ea42c677