### PR TITLE
Add tech docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ To verify the responsive design manually:
 3. Test common viewport widths (e.g., 375px and 1280px) and ensure navigation and forms render correctly.
 
 For automated cross-browser or cross-device testing, you can integrate a service like BrowserStack or add Playwright and run `npx playwright test`.
+
+## Documentation
+
+Additional technical documentation is available in the `docs/` directory:
+
+- `database_schema.md` – overview of the database tables and relationships
+- `api_endpoints.md` – list of API endpoints with parameters
+- `user_guide_athletes.md` – instructions for managing athlete profiles

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -1,0 +1,36 @@
+# API Endpoints
+
+All API routes are prefixed with `/api`. Authentication is required for endpoints that modify data.
+
+## Athlete Profiles
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/athletes` | List athlete profiles (pagination via `page` and `per_page`). |
+| POST | `/api/athletes` | Create a new athlete profile. Requires `user_id`, `primary_sport_id`, `primary_position_id` and `date_of_birth`. |
+| GET | `/api/athletes/<athlete_id>` | Retrieve a single athlete profile. |
+| PUT | `/api/athletes/<athlete_id>` | Update an athlete profile. Auth required. |
+| DELETE | `/api/athletes/<athlete_id>` | Soft-delete an athlete profile. Auth required. |
+
+### Media
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/athletes/<athlete_id>/media` | List media attached to an athlete. |
+| POST | `/api/athletes/<athlete_id>/media` | Upload a file for an athlete. Requires multipart `file` and optional `media_type`. Auth required. |
+| DELETE | `/api/media/<media_id>` | Delete a media entry. Auth required. |
+| GET | `/api/media/<media_id>/download` | Download a media file. |
+
+### Stats
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/athletes/<athlete_id>/stats` | List stats for an athlete. |
+| POST | `/api/athletes/<athlete_id>/stats` | Add or update a stat. Requires `name`. Auth required. |
+| DELETE | `/api/stats/<stat_id>` | Delete a stat entry. Auth required. |
+
+### Search
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/athletes/search` | Search athletes using query parameters such as `q`, `sport`, `position`, `team`, age/height/weight filters. |

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,0 +1,27 @@
+# Database Schema
+
+The backend uses a PostgreSQL database managed through SQLAlchemy. Key tables and relationships are outlined below.
+
+```
+users (user_id PK)
+  |--< user_roles (user_role_id PK)
+  |      |-- user_id FK -> users.user_id
+  |      `-- role_id FK -> roles.role_id
+  |--< user_oauth_accounts (account_id PK)
+  |      `-- user_id FK -> users.user_id
+  `--1 athlete_profiles (athlete_id PK, user_id FK -> users.user_id)
+          |--< athlete_media (media_id PK, athlete_id FK)
+          |--< athlete_stats (stat_id PK, athlete_id FK)
+          `--< athlete_skills (skill_id PK, athlete_id FK)
+
+roles (role_id PK)
+
+sports (sport_id PK)
+  `--< positions (position_id PK, sport_id FK)
+
+athlete_profiles
+  |-- primary_sport_id FK -> sports.sport_id
+  `-- primary_position_id FK -> positions.position_id
+```
+
+Each `AthleteProfile` record is associated with exactly one `User`. Media, stats and skills reference the athlete profile via foreign keys. Sports have many positions, and each athlete is linked to a sport and position.

--- a/docs/user_guide_athletes.md
+++ b/docs/user_guide_athletes.md
@@ -1,0 +1,63 @@
+# Managing Athlete Profiles
+
+This guide explains common tasks for administrators managing athlete profiles through the API.
+
+## Creating a Profile
+
+1. Ensure the related `User` account exists.
+2. Send a `POST` request to `/api/athletes` with JSON body:
+
+```json
+{
+  "user_id": "<user id>",
+  "primary_sport_id": 1,
+  "primary_position_id": 2,
+  "date_of_birth": "1995-09-01"
+}
+```
+
+The response includes the newly created `athlete_id`.
+
+## Updating Details
+
+Use `PUT /api/athletes/<athlete_id>` with the fields you want to change. Example:
+
+```json
+{
+  "bio": "All‑star forward for the home team",
+  "primary_position_id": 3
+}
+```
+
+## Uploading Media
+
+Media files (photos, highlight reels) can be uploaded with:
+
+```
+POST /api/athletes/<athlete_id>/media
+Content-Type: multipart/form-data
+file=<file> media_type=image
+```
+
+List media using `GET /api/athletes/<athlete_id>/media` and delete with `DELETE /api/media/<media_id>`.
+
+## Recording Stats
+
+To add or update stats for a season:
+
+```json
+POST /api/athletes/<athlete_id>/stats
+{
+  "name": "points",
+  "value": "1200",
+  "season": "2023"
+}
+```
+
+## Searching Profiles
+
+Use `GET /api/athletes/search` with query parameters such as `q`, `sport`, `position` or `team` to find athletes.
+
+## Deleting a Profile
+
+A soft delete is performed with `DELETE /api/athletes/<athlete_id>`; the record remains but is hidden from default queries.


### PR DESCRIPTION
## Summary
- document database relationships
- list API endpoints
- provide usage guide for athlete profile management
- link docs from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f3cabd7848327b08934f6dfbbb39f