### PR TITLE
Update Flask-WTF version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Flask-Login==0.6.3
 Flask-Migrate==4.0.5
 Flask-Session==0.5.0
 Flask-SQLAlchemy==3.0.5
-Flask-WTF==1.1.1
+Flask-WTF>=1.2.1
 greenlet==3.2.3
 idna==3.10
 itsdangerous==2.2.0


### PR DESCRIPTION
## Summary
- upgrade Flask-WTF requirement to `>=1.2.1`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ff504f4f88327a4fe3f5cc96b01d3