### PR TITLE
Add relationship from User to AthleteProfile

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -23,6 +23,12 @@ class User(UserMixin, db.Model):
     # Relationships
     roles = db.relationship('Role', secondary='user_roles', back_populates='users')
     oauth_accounts = db.relationship('UserOAuthAccount', back_populates='user', cascade='all, delete-orphan')
+    athlete_profile = db.relationship(
+        'AthleteProfile',
+        back_populates='user',
+        uselist=False,
+        cascade='all, delete-orphan'
+    )
     
     def get_id(self):
         """Required by Flask-Login"""


### PR DESCRIPTION
## Summary
- link User to AthleteProfile with a one-to-one relationship

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ff50546c883278636c803714d635f