### PR TITLE
Add local authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+## User authentication
+
+Local accounts can be created directly in the app. Visit `/auth/register` to
+sign up. New users are automatically logged in and assigned the default `viewer`
+role. Existing users can log in at `/auth/login` using their username or email
+address and password. OAuth logins for Google, GitHub and Microsoft remain
+available when configured.
+
 ## Docker
 
 A `Dockerfile` and `docker-compose.yml` are provided. To run the app with PostgreSQL using Docker:

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,29 +1,52 @@
 {% extends "base.html" %}
 
+{% block title %}Login - {{ super() }}{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
+    <div class="col-md-6 col-lg-4">
+        <div class="card shadow">
             <div class="card-body">
-                <h2 class="card-title text-center mb-4">Login to Your Account</h2>
-                
-                <div class="d-grid gap-2">
-                    <a href="{{ url_for('auth.oauth_login', provider='google') }}" class="btn btn-danger btn-lg">
+                <h2 class="card-title text-center mb-4">Login</h2>
+                <form method="POST">
+                    {{ form.hidden_tag() }}
+                    <div class="mb-3">
+                        {{ form.username_or_email.label(class="form-label") }}
+                        {{ form.username_or_email(class="form-control") }}
+                        {% for err in form.username_or_email.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.password.label(class="form-label") }}
+                        {{ form.password(class="form-control") }}
+                        {% for err in form.password.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="d-grid mb-3">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+                <div class="d-grid gap-2 mb-3">
+                    <a href="{{ url_for('auth.oauth_login', provider='google') }}" class="btn btn-danger">
                         <i class="fab fa-google me-2"></i> Login with Google
                     </a>
-                    
-                    <a href="{{ url_for('auth.oauth_login', provider='github') }}" class="btn btn-dark btn-lg">
+                    <a href="{{ url_for('auth.oauth_login', provider='github') }}" class="btn btn-dark">
                         <i class="fab fa-github me-2"></i> Login with GitHub
                     </a>
-                    
                     {% if config.AZURE_CLIENT_ID %}
-                    <a href="{{ url_for('auth.oauth_login', provider='azure') }}" class="btn btn-primary btn-lg">
+                    <a href="{{ url_for('auth.oauth_login', provider='azure') }}" class="btn btn-primary">
                         <i class="fab fa-microsoft me-2"></i> Login with Microsoft
                     </a>
                     {% endif %}
                 </div>
+                <p class="text-center">
+                    Don't have an account? <a href="{{ url_for('auth.register') }}">Register</a>.
+                </p>
             </div>
         </div>
     </div>
 </div>
 {% endblock %}
+

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block title %}Register - {{ super() }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-4">
+        <div class="card shadow">
+            <div class="card-body">
+                <h2 class="card-title text-center mb-4">Register</h2>
+                <form method="POST">
+                    {{ form.hidden_tag() }}
+                    <div class="mb-3">
+                        {{ form.username.label(class="form-label") }}
+                        {{ form.username(class="form-control") }}
+                        {% for err in form.username.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.email.label(class="form-label") }}
+                        {{ form.email(class="form-control") }}
+                        {% for err in form.email.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.first_name.label(class="form-label") }}
+                        {{ form.first_name(class="form-control") }}
+                        {% for err in form.first_name.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.last_name.label(class="form-label") }}
+                        {{ form.last_name(class="form-control") }}
+                        {% for err in form.last_name.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.password.label(class="form-label") }}
+                        {{ form.password(class="form-control") }}
+                        {% for err in form.password.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="mb-3">
+                        {{ form.confirm.label(class="form-label") }}
+                        {{ form.confirm(class="form-control") }}
+                        {% for err in form.confirm.errors %}
+                        <div class="text-danger small">{{ err }}</div>
+                        {% endfor %}
+                    </div>
+                    <div class="d-grid mb-3">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+                <p class="text-center">
+                    Already have an account? <a href="{{ url_for('auth.login') }}">Login</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User, Role
+
+@pytest.fixture
+def app_instance():
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        # create default viewer role
+        if not Role.query.filter_by(name='viewer').first():
+            db.session.add(Role(name='viewer'))
+            db.session.commit()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def test_register(client, app_instance):
+    data = {
+        'username': 'newuser',
+        'email': 'new@example.com',
+        'first_name': 'New',
+        'last_name': 'User',
+        'password': 'secret',
+        'confirm': 'secret'
+    }
+    resp = client.post('/auth/register', data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Welcome' in resp.data
+    with app_instance.app_context():
+        user = User.query.filter_by(username='newuser').first()
+        assert user is not None
+        assert user.check_password('secret')
+        assert user.roles[0].name == 'viewer'
+
+
+def test_login(client, app_instance):
+    with app_instance.app_context():
+        role = Role.query.filter_by(name='viewer').first()
+        user = User(username='loginuser', email='login@example.com', first_name='Login', last_name='User')
+        user.set_password('secret')
+        if role:
+            user.roles.append(role)
+        db.session.add(user)
+        db.session.commit()
+
+    resp = client.post('/auth/login', data={'username_or_email': 'loginuser', 'password': 'secret'}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Welcome' in resp.data


### PR DESCRIPTION
## Summary
- enable form-based login in `/auth/login`
- add user registration route
- include templates for login and registration with field error display
- add tests for registration and login
- document authentication in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask and other libs)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd2a24e4832797871db8c98f7003