### PR TITLE
Fix Flask-WTF import issue by pinning Werkzeug<3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ requests==2.31.0
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 urllib3==2.4.0
-Werkzeug==3.1.3
+# Flask-WTF still relies on the deprecated 'url_encode' helper removed in
+# Werkzeug 3.0. Pin to a 2.x release until a compatible version of
+# Flask-WTF is available.
+Werkzeug>=2.3,<3.0
 WTForms==3.0.1
 playwright==1.42.0


### PR DESCRIPTION
## Summary
- Flask-WTF relies on the `url_encode` helper that was removed in Werkzeug 3
- Pin Werkzeug to a 2.x release for compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861ff69e3788327aa1ad0d96361e52c