### PR TITLE
Fix Alembic migration chain

### DIFF
--- a/migrations/versions/90e86a8e8360_add_is_deleted_column.py
+++ b/migrations/versions/90e86a8e8360_add_is_deleted_column.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '90e86a8e8360'
-down_revision = '5bb8dbba77e3'
+down_revision = 'cbacbef4e34e'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/915b1c8b9adb_replace_status_with_is_active.py
+++ b/migrations/versions/915b1c8b9adb_replace_status_with_is_active.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '915b1c8b9adb'
-down_revision = '5bb8dbba77e3'
+down_revision = '90e86a8e8360'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/c1fb64894ba8_add_stat_type_and_season.py
+++ b/migrations/versions/c1fb64894ba8_add_stat_type_and_season.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'c1fb64894ba8'
-down_revision = '5bb8dbba77e3'
+down_revision = '915b1c8b9adb'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- update down_revision values so migrations form a linear chain

## Testing
- `FLASK_APP=run.py FLASK_ENV=testing flask db upgrade` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686206a0744c8327bd21c81af94b623a