### PR TITLE
Add db initialization step

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ This repository contains a Flask API backend and a React frontend used to manage
    - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
    - `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
    - `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
-3. **Database migrations**
-   ```bash
-   flask db upgrade
-   ```
-4. **Run the server**
+### Initialize the database
+Run database migrations to create all tables:
+
+```bash
+flask db upgrade
+```
+
+3. **Run the server**
    ```bash
    flask run
    ```


### PR DESCRIPTION
## Summary
- clarify database initialization in the backend setup instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862069fd70c8327b58bdc3c05ff8d92