### PR TITLE
Fix Revises lines in migrations

### DIFF
--- a/migrations/versions/5bb8dbba77e3_fix_user_roles_relationship.py
+++ b/migrations/versions/5bb8dbba77e3_fix_user_roles_relationship.py
@@ -1,7 +1,7 @@
 """Fix user roles relationship
 
 Revision ID: 5bb8dbba77e3
-Revises: 
+Revises: None
 Create Date: 2025-06-16 15:38:46.088450
 
 """

--- a/migrations/versions/90e86a8e8360_add_is_deleted_column.py
+++ b/migrations/versions/90e86a8e8360_add_is_deleted_column.py
@@ -1,7 +1,7 @@
 """Add is_deleted column to athlete_profiles
 
 Revision ID: 90e86a8e8360
-Revises: 5bb8dbba77e3
+Revises: cbacbef4e34e
 Create Date: 2025-06-17 00:00:00.000000
 """
 

--- a/migrations/versions/915b1c8b9adb_replace_status_with_is_active.py
+++ b/migrations/versions/915b1c8b9adb_replace_status_with_is_active.py
@@ -1,7 +1,7 @@
 """Replace user status enum with is_active boolean
 
 Revision ID: 915b1c8b9adb
-Revises: 5bb8dbba77e3
+Revises: 90e86a8e8360
 Create Date: 2025-06-27 18:32:32.000000
 
 """

--- a/migrations/versions/c1fb64894ba8_add_stat_type_and_season.py
+++ b/migrations/versions/c1fb64894ba8_add_stat_type_and_season.py
@@ -1,7 +1,7 @@
 """add stat_type and season to athlete_stats
 
 Revision ID: c1fb64894ba8
-Revises: 5bb8dbba77e3
+Revises: 915b1c8b9adb
 Create Date: 2025-07-01 00:00:00.000000
 """
 from alembic import op


### PR DESCRIPTION
## Summary
- match each migration docstring's `Revises:` value to its `down_revision`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862aac54d8c83278d33143d8bad7235