### PR TITLE
Add NBA stats integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repository contains a Flask API backend and a React frontend used to manage
    - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
    - `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
    - `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` and `AZURE_TENANT_ID`
+   - `NBA_API_TOKEN` optional access token for NBA stats API
+   - `NBA_API_BASE_URL` override base URL for NBA API (optional)
 ### Initialize the database
 Run database migrations to create all tables:
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -14,3 +14,7 @@ __all__ = [
     'AthleteSkill',
 ]
 
+from .team import NBATeam
+from .game import NBAGame
+
+__all__.extend(['NBATeam', 'NBAGame'])

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -1,0 +1,19 @@
+from app import db
+from app.models.base import BaseModel
+
+class NBAGame(BaseModel):
+    __tablename__ = 'nba_games'
+
+    game_id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date)
+    season = db.Column(db.Integer)
+    home_team_id = db.Column(db.Integer, db.ForeignKey('nba_teams.team_id'))
+    visitor_team_id = db.Column(db.Integer, db.ForeignKey('nba_teams.team_id'))
+    home_team_score = db.Column(db.Integer)
+    visitor_team_score = db.Column(db.Integer)
+
+    home_team = db.relationship('NBATeam', foreign_keys=[home_team_id], back_populates='games_home')
+    visitor_team = db.relationship('NBATeam', foreign_keys=[visitor_team_id], back_populates='games_away')
+
+    def __repr__(self):
+        return f'<NBAGame {self.game_id}>'

--- a/app/models/team.py
+++ b/app/models/team.py
@@ -1,0 +1,19 @@
+from app import db
+from app.models.base import BaseModel
+
+class NBATeam(BaseModel):
+    __tablename__ = 'nba_teams'
+
+    team_id = db.Column(db.Integer, primary_key=True)
+    abbreviation = db.Column(db.String(10))
+    city = db.Column(db.String(50))
+    conference = db.Column(db.String(20))
+    division = db.Column(db.String(50))
+    full_name = db.Column(db.String(100))
+    name = db.Column(db.String(100))
+
+    games_home = db.relationship('NBAGame', back_populates='home_team', foreign_keys='NBAGame.home_team_id')
+    games_away = db.relationship('NBAGame', back_populates='visitor_team', foreign_keys='NBAGame.visitor_team_id')
+
+    def __repr__(self):
+        return f'<NBATeam {self.full_name}>'

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+from .athlete_service import *  # noqa
+from .media_service import *  # noqa
+from .nba_service import *  # noqa

--- a/app/services/nba_service.py
+++ b/app/services/nba_service.py
@@ -1,0 +1,119 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+import requests
+from flask import current_app
+
+from app import db
+from app.models import NBATeam, NBAGame, AthleteProfile, AthleteStat
+
+
+class NBAAPIClient:
+    """Simple client for the public NBA stats API."""
+
+    def __init__(self, base_url: Optional[str] = None, token: Optional[str] = None):
+        self.base_url = base_url or current_app.config.get('NBA_API_BASE_URL', 'https://www.balldontlie.io/api/v1')
+        self.session = requests.Session()
+        self.token = token or current_app.config.get('NBA_API_TOKEN')
+        if self.token:
+            self.session.headers.update({'Authorization': f'Bearer {self.token}'})
+
+    def _get(self, endpoint: str, params: Optional[dict] = None):
+        url = f"{self.base_url}{endpoint}"
+        resp = self.session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_teams(self):
+        return self._get('/teams').get('data', [])
+
+    def get_games(self, team_id: int, season: Optional[int] = None):
+        params = {'team_ids[]': team_id}
+        if season:
+            params['seasons[]'] = season
+        return self._get('/games', params=params).get('data', [])
+
+    def get_player_season_avg(self, player_id: int, season: Optional[int] = None):
+        params = {'player_ids[]': player_id}
+        if season:
+            params['season'] = season
+        data = self._get('/season_averages', params=params)
+        if data.get('data'):
+            return data['data'][0]
+        return None
+
+
+def sync_teams(client: NBAAPIClient):
+    """Fetch and store all NBA teams."""
+    teams = client.get_teams()
+    for t in teams:
+        team = NBATeam.query.get(t['id'])
+        if not team:
+            team = NBATeam(team_id=t['id'])
+        team.abbreviation = t.get('abbreviation')
+        team.city = t.get('city')
+        team.conference = t.get('conference')
+        team.division = t.get('division')
+        team.full_name = t.get('full_name')
+        team.name = t.get('name')
+        db.session.add(team)
+    db.session.commit()
+    logging.getLogger(__name__).info("Synced %d NBA teams", len(teams))
+    return teams
+
+
+def sync_games(client: NBAAPIClient, team_id: int, season: Optional[int] = None):
+    """Fetch game logs for a team and store them."""
+    games = client.get_games(team_id=team_id, season=season)
+    for g in games:
+        game = NBAGame.query.get(g['id'])
+        if not game:
+            game = NBAGame(game_id=g['id'])
+        game.date = datetime.fromisoformat(g['date'].rstrip('Z')).date()
+        game.season = g.get('season')
+        game.home_team_id = g['home_team']['id']
+        game.visitor_team_id = g['visitor_team']['id']
+        game.home_team_score = g.get('home_team_score')
+        game.visitor_team_score = g.get('visitor_team_score')
+        db.session.add(game)
+    db.session.commit()
+    logging.getLogger(__name__).info("Synced %d games for team %s", len(games), team_id)
+    return games
+
+
+def sync_player_stats(client: NBAAPIClient, athlete: AthleteProfile, season: Optional[int] = None):
+    """Fetch season averages for an athlete and store as stats."""
+    if not athlete.current_team:
+        return None
+    player_id = getattr(athlete, 'nba_player_id', None)
+    if not player_id:
+        return None
+    data = client.get_player_season_avg(player_id, season=season)
+    if not data:
+        return None
+    mapping = {
+        'pts': 'PointsPerGame',
+        'reb': 'ReboundsPerGame',
+        'ast': 'AssistsPerGame',
+    }
+    for api_field, stat_name in mapping.items():
+        stat = AthleteStat.query.filter_by(
+            athlete_id=athlete.athlete_id,
+            name=stat_name,
+            season=str(data.get('season')),
+        ).first()
+        if not stat:
+            stat = AthleteStat(
+                athlete_id=athlete.athlete_id,
+                name=stat_name,
+                season=str(data.get('season')),
+            )
+        stat.value = str(data.get(api_field))
+        stat.stat_type = 'NBA'
+        db.session.add(stat)
+    db.session.commit()
+    logging.getLogger(__name__).info(
+        "Synced stats for athlete %s from NBA season %s", athlete.athlete_id, data.get('season')
+    )
+    return data

--- a/config.py
+++ b/config.py
@@ -18,6 +18,8 @@ class Config:
     AZURE_CLIENT_ID = os.environ.get('AZURE_CLIENT_ID')
     AZURE_CLIENT_SECRET = os.environ.get('AZURE_CLIENT_SECRET')
     AZURE_TENANT_ID = os.environ.get('AZURE_TENANT_ID')
+    NBA_API_BASE_URL = os.environ.get("NBA_API_BASE_URL") or "https://www.balldontlie.io/api/v1"
+    NBA_API_TOKEN = os.environ.get("NBA_API_TOKEN")
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -25,3 +25,10 @@ athlete_profiles
 ```
 
 Each `AthleteProfile` record is associated with exactly one `User`. Media, stats and skills reference the athlete profile via foreign keys. Sports have many positions, and each athlete is linked to a sport and position.
+
+Additional tables for NBA integration:
+
+```
+nba_teams (team_id PK)
+  |--< nba_games (game_id PK, home_team_id FK -> nba_teams.team_id, visitor_team_id FK -> nba_teams.team_id)
+```

--- a/migrations/versions/abcd1234add_nba_tables.py
+++ b/migrations/versions/abcd1234add_nba_tables.py
@@ -1,0 +1,47 @@
+"""add nba team and game tables
+
+Revision ID: abcd1234add
+Revises: c1fb64894ba8
+Create Date: 2025-07-02 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'abcd1234add'
+down_revision = 'c1fb64894ba8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'nba_teams',
+        sa.Column('team_id', sa.Integer(), primary_key=True),
+        sa.Column('abbreviation', sa.String(length=10)),
+        sa.Column('city', sa.String(length=50)),
+        sa.Column('conference', sa.String(length=20)),
+        sa.Column('division', sa.String(length=50)),
+        sa.Column('full_name', sa.String(length=100)),
+        sa.Column('name', sa.String(length=100)),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        'nba_games',
+        sa.Column('game_id', sa.Integer(), primary_key=True),
+        sa.Column('date', sa.Date()),
+        sa.Column('season', sa.Integer()),
+        sa.Column('home_team_id', sa.Integer(), sa.ForeignKey('nba_teams.team_id')),
+        sa.Column('visitor_team_id', sa.Integer(), sa.ForeignKey('nba_teams.team_id')),
+        sa.Column('home_team_score', sa.Integer()),
+        sa.Column('visitor_team_score', sa.Integer()),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('nba_games')
+    op.drop_table('nba_teams')

--- a/tests/test_nba_service.py
+++ b/tests/test_nba_service.py
@@ -1,0 +1,76 @@
+import os
+import sys
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import NBATeam, NBAGame
+from app.services import nba_service
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def app_ctx(app_instance):
+    with app_instance.app_context():
+        yield
+
+
+def test_sync_teams(app_ctx):
+    sample = {
+        'data': [
+            {
+                'id': 1,
+                'abbreviation': 'LAL',
+                'city': 'Los Angeles',
+                'conference': 'West',
+                'division': 'Pacific',
+                'full_name': 'Los Angeles Lakers',
+                'name': 'Lakers',
+            }
+        ]
+    }
+    client = nba_service.NBAAPIClient()
+    with patch.object(client, '_get', return_value=sample):
+        teams = nba_service.sync_teams(client)
+    assert NBATeam.query.count() == 1
+    assert teams[0]['id'] == 1
+
+
+def test_sync_games(app_ctx):
+    # create teams to satisfy FKs
+    team1 = NBATeam(team_id=1, name='Lakers')
+    team2 = NBATeam(team_id=2, name='Heat')
+    db.session.add_all([team1, team2])
+    db.session.commit()
+
+    sample_games = {
+        'data': [
+            {
+                'id': 10,
+                'date': '2024-01-01T00:00:00Z',
+                'season': 2024,
+                'home_team': {'id': 1},
+                'visitor_team': {'id': 2},
+                'home_team_score': 100,
+                'visitor_team_score': 90,
+            }
+        ]
+    }
+    client = nba_service.NBAAPIClient()
+    with patch.object(client, '_get', return_value=sample_games):
+        games = nba_service.sync_games(client, team_id=1, season=2024)
+    assert NBAGame.query.count() == 1
+    assert games[0]['id'] == 10


### PR DESCRIPTION
## Summary
- integrate NBA stats API via new service
- add NBA team & game models and migration
- document NBA API environment variables & schema changes
- implement NBA service tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862d64fad448327af39f14664f47de9