### PR TITLE
Add NFL API integration

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     'AthleteSkill',
 ]
 
-from .team import NBATeam, MLBTeam
+from .team import NBATeam, MLBTeam, NFLTeam
 from .game import NBAGame
 
-__all__.extend(['NBATeam', 'NBAGame', 'MLBTeam'])
+__all__.extend(['NBATeam', 'NBAGame', 'MLBTeam', 'NFLTeam'])

--- a/app/models/team.py
+++ b/app/models/team.py
@@ -31,3 +31,17 @@ class MLBTeam(BaseModel):
 
     def __repr__(self):
         return f'<MLBTeam {self.name}>'
+
+
+class NFLTeam(BaseModel):
+    __tablename__ = 'nfl_teams'
+
+    team_id = db.Column(db.Integer, primary_key=True)
+    abbreviation = db.Column(db.String(10))
+    city = db.Column(db.String(50))
+    conference = db.Column(db.String(50))
+    division = db.Column(db.String(50))
+    name = db.Column(db.String(100))
+
+    def __repr__(self):
+        return f'<NFLTeam {self.name}>'

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -2,3 +2,4 @@ from .athlete_service import *  # noqa
 from .media_service import *  # noqa
 from .nba_service import *  # noqa
 from .mlb_service import *  # noqa
+from .nfl_service import *  # noqa

--- a/app/services/nfl_service.py
+++ b/app/services/nfl_service.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Optional
+
+import requests
+from flask import current_app
+
+from app import db
+from app.models import NFLTeam, AthleteProfile, AthleteStat
+
+
+class NFLAPIClient:
+    """Client for a public NFL stats API."""
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = base_url or current_app.config.get(
+            "NFL_API_BASE_URL", "https://api.nfl.com/v1"
+        )
+        self.session = requests.Session()
+
+    def _get(self, endpoint: str, params: Optional[dict] = None):
+        url = f"{self.base_url}{endpoint}"
+        resp = self.session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_teams(self):
+        data = self._get("/teams")
+        return data.get("teams", [])
+
+    def get_player_stats(
+        self, player_id: int, season: Optional[int] = None, group: str = "offense"
+    ):
+        params = {"group": group}
+        if season:
+            params["season"] = season
+        data = self._get(f"/players/{player_id}/stats", params=params)
+        return data.get("stats", {})
+
+
+def sync_teams(client: NFLAPIClient):
+    """Fetch and store all NFL teams."""
+    teams = client.get_teams()
+    for t in teams:
+        team = NFLTeam.query.get(t["id"])
+        if not team:
+            team = NFLTeam(team_id=t["id"])
+        team.name = t.get("name")
+        team.abbreviation = t.get("abbreviation")
+        team.city = t.get("city")
+        team.conference = t.get("conference")
+        team.division = t.get("division")
+        db.session.add(team)
+    db.session.commit()
+    logging.getLogger(__name__).info("Synced %d NFL teams", len(teams))
+    return teams
+
+
+def sync_player_stats(
+    client: NFLAPIClient, athlete: AthleteProfile, season: Optional[int] = None
+):
+    """Fetch NFL stats for an athlete and store them."""
+    player_id = getattr(athlete, "nfl_player_id", None)
+    if not player_id:
+        return None
+
+    offense = client.get_player_stats(player_id, season=season, group="offense") or {}
+    defense = client.get_player_stats(player_id, season=season, group="defense") or {}
+
+    mappings = {
+        "NFL_OFFENSE": {
+            "passingYards": "PassingYards",
+            "rushingYards": "RushingYards",
+            "receivingYards": "ReceivingYards",
+        },
+        "NFL_DEFENSE": {"tackles": "Tackles", "sacks": "Sacks"},
+    }
+
+    season_str = str(season) if season else None
+
+    for stat_type, mapping in mappings.items():
+        source = offense if stat_type == "NFL_OFFENSE" else defense
+        for api_field, stat_name in mapping.items():
+            if api_field not in source:
+                continue
+            stat = AthleteStat.query.filter_by(
+                athlete_id=athlete.athlete_id,
+                name=stat_name,
+                season=season_str,
+            ).first()
+            if not stat:
+                stat = AthleteStat(
+                    athlete_id=athlete.athlete_id,
+                    name=stat_name,
+                    season=season_str,
+                )
+            stat.value = str(source.get(api_field))
+            stat.stat_type = stat_type
+            db.session.add(stat)
+
+    db.session.commit()
+    logging.getLogger(__name__).info(
+        "Synced NFL stats for athlete %s season %s", athlete.athlete_id, season_str
+    )
+    return {"offense": offense, "defense": defense}

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config:
     AZURE_TENANT_ID = os.environ.get('AZURE_TENANT_ID')
     NBA_API_BASE_URL = os.environ.get("NBA_API_BASE_URL") or "https://www.balldontlie.io/api/v1"
     NBA_API_TOKEN = os.environ.get("NBA_API_TOKEN")
+    NFL_API_BASE_URL = os.environ.get("NFL_API_BASE_URL") or "https://api.nfl.com/v1"
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -37,3 +37,8 @@ Additional tables for MLB integration:
 ```
 mlb_teams (team_id PK)
 ```
+
+Additional tables for NFL integration:
+```
+nfl_teams (team_id PK)
+```

--- a/tests/test_nfl_service.py
+++ b/tests/test_nfl_service.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import NFLTeam, AthleteProfile
+from app.services import nfl_service
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def app_ctx(app_instance):
+    with app_instance.app_context():
+        yield
+
+
+def test_sync_teams(app_ctx):
+    sample = {
+        'teams': [
+            {
+                'id': 1,
+                'name': 'Patriots',
+                'abbreviation': 'NE',
+                'city': 'New England',
+                'conference': 'AFC',
+                'division': 'East',
+            }
+        ]
+    }
+    client = nfl_service.NFLAPIClient()
+    with patch.object(client, '_get', return_value=sample):
+        teams = nfl_service.sync_teams(client)
+    assert NFLTeam.query.count() == 1
+    assert teams[0]['id'] == 1
+
+
+def test_sync_player_stats(app_ctx):
+    athlete = AthleteProfile(user_id='u1', date_of_birth=date.fromisoformat('2000-01-01'))
+    setattr(athlete, 'nfl_player_id', 12)
+    db.session.add(athlete)
+    db.session.commit()
+
+    offense = {'passingYards': 4000}
+    defense = {'tackles': 80}
+
+    client = nfl_service.NFLAPIClient()
+    with patch.object(client, 'get_player_stats', side_effect=[offense, defense]):
+        nfl_service.sync_player_stats(client, athlete, season=2024)
+
+    stats = {s.name: s for s in athlete.stats}
+    assert stats['PassingYards'].value == '4000'
+    assert stats['Tackles'].value == '80'


### PR DESCRIPTION
## Summary
- create NFLTeam model
- integrate NFL API client and synchronization helpers
- expose NFL services
- document NFL table in database schema
- test NFL service utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862d955d3d88327b2322eb3ba5016ef