### PR TITLE
Implement NHL API client and models

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     'AthleteSkill',
 ]
 
-from .team import NBATeam, MLBTeam, NFLTeam
-from .game import NBAGame
+from .team import NBATeam, MLBTeam, NFLTeam, NHLTeam
+from .game import NBAGame, NHLGame
 
-__all__.extend(['NBATeam', 'NBAGame', 'MLBTeam', 'NFLTeam'])
+__all__.extend(['NBATeam', 'NBAGame', 'MLBTeam', 'NFLTeam', 'NHLTeam', 'NHLGame'])

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -17,3 +17,21 @@ class NBAGame(BaseModel):
 
     def __repr__(self):
         return f'<NBAGame {self.game_id}>'
+
+
+class NHLGame(BaseModel):
+    __tablename__ = 'nhl_games'
+
+    game_id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date)
+    season = db.Column(db.String(10))
+    home_team_id = db.Column(db.Integer, db.ForeignKey('nhl_teams.team_id'))
+    visitor_team_id = db.Column(db.Integer, db.ForeignKey('nhl_teams.team_id'))
+    home_team_score = db.Column(db.Integer)
+    visitor_team_score = db.Column(db.Integer)
+
+    home_team = db.relationship('NHLTeam', foreign_keys=[home_team_id], back_populates='games_home')
+    visitor_team = db.relationship('NHLTeam', foreign_keys=[visitor_team_id], back_populates='games_away')
+
+    def __repr__(self):
+        return f'<NHLGame {self.game_id}>'

--- a/app/models/team.py
+++ b/app/models/team.py
@@ -45,3 +45,24 @@ class NFLTeam(BaseModel):
 
     def __repr__(self):
         return f'<NFLTeam {self.name}>'
+
+
+class NHLTeam(BaseModel):
+    __tablename__ = 'nhl_teams'
+
+    team_id = db.Column(db.Integer, primary_key=True)
+    abbreviation = db.Column(db.String(10))
+    name = db.Column(db.String(100))
+    location = db.Column(db.String(50))
+    conference = db.Column(db.String(50))
+    division = db.Column(db.String(50))
+    wins = db.Column(db.Integer)
+    losses = db.Column(db.Integer)
+    overtime_losses = db.Column(db.Integer)
+    points = db.Column(db.Integer)
+
+    games_home = db.relationship('NHLGame', back_populates='home_team', foreign_keys='NHLGame.home_team_id')
+    games_away = db.relationship('NHLGame', back_populates='visitor_team', foreign_keys='NHLGame.visitor_team_id')
+
+    def __repr__(self):
+        return f'<NHLTeam {self.name}>'

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -3,3 +3,4 @@ from .media_service import *  # noqa
 from .nba_service import *  # noqa
 from .mlb_service import *  # noqa
 from .nfl_service import *  # noqa
+from .nhl_service import *  # noqa

--- a/app/services/nhl_service.py
+++ b/app/services/nhl_service.py
@@ -1,0 +1,148 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+import requests
+from flask import current_app
+
+from app import db
+from app.models import NHLTeam, NHLGame, AthleteProfile, AthleteStat
+
+
+class NHLAPIClient:
+    """Client for the public NHL stats API."""
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = base_url or current_app.config.get(
+            "NHL_API_BASE_URL", "https://statsapi.web.nhl.com/api/v1"
+        )
+        self.session = requests.Session()
+
+    def _get(self, endpoint: str, params: Optional[dict] = None):
+        url = f"{self.base_url}{endpoint}"
+        resp = self.session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_teams(self):
+        data = self._get("/teams")
+        return data.get("teams", [])
+
+    def get_standings(self):
+        data = self._get("/standings")
+        return data.get("records", [])
+
+    def get_games(self, team_id: int, season: Optional[str] = None):
+        params = {"teamId": team_id}
+        if season:
+            params["season"] = season
+        data = self._get("/schedule", params=params)
+        games = []
+        for d in data.get("dates", []):
+            games.extend(d.get("games", []))
+        return games
+
+    def get_player_stats(self, player_id: int, season: Optional[str] = None):
+        params = {"stats": "statsSingleSeason"}
+        if season:
+            params["season"] = season
+        data = self._get(f"/people/{player_id}/stats", params=params)
+        if data.get("stats"):
+            splits = data["stats"][0].get("splits", [])
+            if splits:
+                return splits[0].get("stat", {})
+        return None
+
+
+def sync_teams(client: NHLAPIClient):
+    """Fetch and store all NHL teams."""
+    teams = client.get_teams()
+    for t in teams:
+        team = NHLTeam.query.get(t["id"])
+        if not team:
+            team = NHLTeam(team_id=t["id"])
+        team.name = t.get("name")
+        team.abbreviation = t.get("abbreviation")
+        team.location = t.get("locationName") or t.get("teamName")
+        team.division = (t.get("division") or {}).get("name")
+        team.conference = (t.get("conference") or {}).get("name")
+        db.session.add(team)
+    db.session.commit()
+    logging.getLogger(__name__).info("Synced %d NHL teams", len(teams))
+    return teams
+
+
+def sync_standings(client: NHLAPIClient):
+    """Fetch standings and update team records."""
+    records = client.get_standings()
+    for r in records:
+        for tr in r.get("teamRecords", []):
+            team_id = tr["team"]["id"]
+            team = NHLTeam.query.get(team_id)
+            if not team:
+                continue
+            league = tr.get("leagueRecord", {})
+            team.wins = league.get("wins")
+            team.losses = league.get("losses")
+            team.overtime_losses = league.get("ot")
+            team.points = tr.get("points")
+            db.session.add(team)
+    db.session.commit()
+    logging.getLogger(__name__).info("Synced NHL standings")
+    return records
+
+
+def sync_games(client: NHLAPIClient, team_id: int, season: Optional[str] = None):
+    """Fetch schedule for a team and store the games."""
+    games = client.get_games(team_id=team_id, season=season)
+    for g in games:
+        game_id = g["gamePk"]
+        game = NHLGame.query.get(game_id)
+        if not game:
+            game = NHLGame(game_id=game_id)
+        game.date = datetime.fromisoformat(g["gameDate"].rstrip("Z")).date()
+        game.season = g.get("season")
+        game.home_team_id = g["teams"]["home"]["team"]["id"]
+        game.visitor_team_id = g["teams"]["away"]["team"]["id"]
+        game.home_team_score = g["teams"]["home"].get("score")
+        game.visitor_team_score = g["teams"]["away"].get("score")
+        db.session.add(game)
+    db.session.commit()
+    logging.getLogger(__name__).info(
+        "Synced %d NHL games for team %s", len(games), team_id
+    )
+    return games
+
+
+def sync_player_stats(
+    client: NHLAPIClient, athlete: AthleteProfile, season: Optional[str] = None
+):
+    """Fetch NHL stats for an athlete and store them."""
+    player_id = getattr(athlete, "nhl_player_id", None)
+    if not player_id:
+        return None
+
+    data = client.get_player_stats(player_id, season=season) or {}
+
+    mapping = {"goals": "Goals", "assists": "Assists", "points": "Points"}
+    season_str = str(season) if season else None
+
+    for api_field, stat_name in mapping.items():
+        if api_field not in data:
+            continue
+        stat = AthleteStat.query.filter_by(
+            athlete_id=athlete.athlete_id, name=stat_name, season=season_str
+        ).first()
+        if not stat:
+            stat = AthleteStat(
+                athlete_id=athlete.athlete_id, name=stat_name, season=season_str
+            )
+        stat.value = str(data.get(api_field))
+        stat.stat_type = "NHL"
+        db.session.add(stat)
+
+    db.session.commit()
+    logging.getLogger(__name__).info(
+        "Synced NHL stats for athlete %s season %s", athlete.athlete_id, season_str
+    )
+    return data

--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ class Config:
     NBA_API_BASE_URL = os.environ.get("NBA_API_BASE_URL") or "https://www.balldontlie.io/api/v1"
     NBA_API_TOKEN = os.environ.get("NBA_API_TOKEN")
     NFL_API_BASE_URL = os.environ.get("NFL_API_BASE_URL") or "https://api.nfl.com/v1"
+    NHL_API_BASE_URL = os.environ.get("NHL_API_BASE_URL") or "https://statsapi.web.nhl.com/api/v1"
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/tests/test_nhl_service.py
+++ b/tests/test_nhl_service.py
@@ -1,0 +1,121 @@
+import os
+import sys
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import NHLTeam, NHLGame, AthleteProfile
+from app.services import nhl_service
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def app_ctx(app_instance):
+    with app_instance.app_context():
+        yield
+
+
+def test_sync_teams(app_ctx):
+    sample = {
+        'teams': [
+            {
+                'id': 1,
+                'name': 'Devils',
+                'abbreviation': 'NJD',
+                'locationName': 'New Jersey',
+                'division': {'name': 'Metro'},
+                'conference': {'name': 'East'},
+            }
+        ]
+    }
+    client = nhl_service.NHLAPIClient()
+    with patch.object(client, '_get', return_value=sample):
+        teams = nhl_service.sync_teams(client)
+    assert NHLTeam.query.count() == 1
+    assert teams[0]['id'] == 1
+
+
+def test_sync_standings(app_ctx):
+    team = NHLTeam(team_id=1, name='Devils')
+    db.session.add(team)
+    db.session.commit()
+    records = {
+        'records': [
+            {
+                'teamRecords': [
+                    {
+                        'team': {'id': 1},
+                        'leagueRecord': {'wins': 10, 'losses': 5, 'ot': 2},
+                        'points': 22,
+                    }
+                ]
+            }
+        ]
+    }
+    client = nhl_service.NHLAPIClient()
+    with patch.object(client, '_get', return_value=records):
+        nhl_service.sync_standings(client)
+    team = NHLTeam.query.get(1)
+    assert team.wins == 10
+    assert team.points == 22
+
+
+def test_sync_games(app_ctx):
+    home = NHLTeam(team_id=1, name='Devils')
+    away = NHLTeam(team_id=2, name='Rangers')
+    db.session.add_all([home, away])
+    db.session.commit()
+    games_data = {
+        'dates': [
+            {
+                'games': [
+                    {
+                        'gamePk': 99,
+                        'gameDate': '2024-01-01T00:00:00Z',
+                        'season': '20242025',
+                        'teams': {
+                            'home': {'team': {'id': 1}, 'score': 3},
+                            'away': {'team': {'id': 2}, 'score': 2},
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+    client = nhl_service.NHLAPIClient()
+    with patch.object(client, '_get', return_value=games_data):
+        games = nhl_service.sync_games(client, team_id=1, season='20242025')
+    assert NHLGame.query.count() == 1
+    assert games[0]['gamePk'] == 99
+
+
+def test_sync_player_stats(app_ctx):
+    athlete = AthleteProfile(user_id='u1', date_of_birth=date.fromisoformat('2000-01-01'))
+    setattr(athlete, 'nhl_player_id', 88)
+    db.session.add(athlete)
+    db.session.commit()
+
+    stats = {'goals': 30, 'assists': 40, 'points': 70}
+    client = nhl_service.NHLAPIClient()
+    with patch.object(client, 'get_player_stats', return_value=stats):
+        nhl_service.sync_player_stats(client, athlete, season='20242025')
+
+    stored = {s.name: s for s in athlete.stats}
+    assert stored['Goals'].value == '30'
+    assert stored['Assists'].value == '40'
+    assert stored['Points'].value == '70'
+


### PR DESCRIPTION
## Summary
- add models for NHL teams and games
- integrate NHL API to pull teams, standings, games and player stats
- expose NHL service in service package
- add default config for NHL API URL
- test NHL service operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862dab6527c83279cf1b417b4d9453f