### PR TITLE
Add APScheduler sync jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ flask db upgrade
    flask run
    ```
 
+4. **Scheduled jobs** (optional)
+   Set `ENABLE_SCHEDULER=true` in your `.env` to start APScheduler with nightly
+   and weekly sync tasks when the Flask app launches. Game results are pulled
+   each night at 2 AM and player stats update every Sunday at 3 AM.
+
 ## Frontend setup (React)
 
 ```bash

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from flask_migrate import Migrate
 from flask_login import LoginManager
 from authlib.integrations.flask_client import OAuth
 from config import config
+from .scheduler import init_scheduler
 
 # Initialize extensions
 db = SQLAlchemy()
@@ -40,13 +41,16 @@ def create_app(config_name='development'):
 
     from app.api import bp as api_bp
     app.register_blueprint(api_bp)
+
+    if app.config.get('ENABLE_SCHEDULER'):
+        init_scheduler(app)
     
     # User loader
     @login_manager.user_loader
     def load_user(user_id):
         from app.models.user import User
         return User.query.get(user_id)
-    
+
     return app
 
 def configure_oauth(app):

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,0 +1,49 @@
+from datetime import date
+import logging
+
+from app import db
+from app.models import AthleteProfile, NBATeam, NHLTeam
+from app.services import nba_service, nfl_service, mlb_service, nhl_service
+
+logger = logging.getLogger(__name__)
+
+
+def nightly_sync_games():
+    """Sync team lists and game results for the current season."""
+    year = date.today().year
+
+    nba_client = nba_service.NBAAPIClient()
+    nba_service.sync_teams(nba_client)
+    for team in NBATeam.query.all():
+        nba_service.sync_games(nba_client, team.team_id, season=year)
+
+    nhl_client = nhl_service.NHLAPIClient()
+    nhl_service.sync_teams(nhl_client)
+    for team in NHLTeam.query.all():
+        nhl_service.sync_games(nhl_client, team.team_id, season=str(year))
+
+    logger.info("Nightly game sync complete")
+
+
+def weekly_sync_player_stats():
+    """Update player statistics across all sports."""
+    year = date.today().year
+
+    nba_client = nba_service.NBAAPIClient()
+    nfl_client = nfl_service.NFLAPIClient()
+    mlb_client = mlb_service.MLBAPIClient()
+    nhl_client = nhl_service.NHLAPIClient()
+
+    for athlete in AthleteProfile.query.all():
+        sport = athlete.primary_sport.code if athlete.primary_sport else None
+        if sport == "NBA":
+            nba_service.sync_player_stats(nba_client, athlete, season=year)
+        elif sport == "NFL":
+            nfl_service.sync_player_stats(nfl_client, athlete, season=year)
+        elif sport == "MLB":
+            mlb_service.sync_player_stats(mlb_client, athlete, season=year)
+        elif sport == "NHL":
+            nhl_service.sync_player_stats(nhl_client, athlete, season=str(year))
+
+    logger.info("Weekly player stats sync complete")
+

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,27 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from flask import Flask
+
+from . import jobs
+
+
+def init_scheduler(app: Flask) -> BackgroundScheduler:
+    """Initialize and start the APScheduler instance."""
+    scheduler = BackgroundScheduler()
+
+    def _job(func):
+        def wrapper():
+            with app.app_context():
+                func()
+        return wrapper
+
+    scheduler.add_job(_job(jobs.nightly_sync_games), CronTrigger(hour=2))
+    scheduler.add_job(
+        _job(jobs.weekly_sync_player_stats),
+        CronTrigger(day_of_week="sun", hour=3),
+    )
+
+    scheduler.start()
+    return scheduler
+

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ class Config:
     NBA_API_TOKEN = os.environ.get("NBA_API_TOKEN")
     NFL_API_BASE_URL = os.environ.get("NFL_API_BASE_URL") or "https://api.nfl.com/v1"
     NHL_API_BASE_URL = os.environ.get("NHL_API_BASE_URL") or "https://statsapi.web.nhl.com/api/v1"
+    ENABLE_SCHEDULER = os.environ.get('ENABLE_SCHEDULER', 'false').lower() == 'true'
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ WTForms
 playwright
 Pillow
 Werkzeug>=2.3,<3.0
+APScheduler


### PR DESCRIPTION
## Summary
- introduce APScheduler for automatic data refresh
- configure scheduler with environment toggle
- document scheduled job usage
- add requirements for APScheduler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_6862e536644083278045ca213ee694f7