### PR TITLE
Add caching and rate limiting for sports API clients

### DIFF
--- a/app/services/http_utils.py
+++ b/app/services/http_utils.py
@@ -2,6 +2,8 @@ import logging
 import time
 from typing import Optional
 
+from .rate_limit import RateLimiter
+
 import requests
 
 
@@ -12,12 +14,15 @@ def request_with_retry(
     retries: int = 3,
     backoff_factor: float = 1.0,
     logger: Optional[logging.Logger] = None,
+    rate_limiter: Optional[RateLimiter] = None,
     **kwargs,
 ) -> requests.Response:
-    """Perform an HTTP request with retry and exponential backoff."""
+    """Perform an HTTP request with retry, backoff and optional rate limiting."""
     logger = logger or logging.getLogger(__name__)
     for attempt in range(1, retries + 1):
         try:
+            if rate_limiter:
+                rate_limiter.wait()
             resp = session.request(method, url, **kwargs)
             resp.raise_for_status()
             return resp

--- a/app/services/nfl_service.py
+++ b/app/services/nfl_service.py
@@ -3,7 +3,9 @@ from typing import Optional
 
 import requests
 from flask import current_app
+from cachelib import SimpleCache
 from .http_utils import request_with_retry
+from .rate_limit import RateLimiter
 
 from app import db
 from app.models import NFLTeam, AthleteProfile, AthleteStat
@@ -13,11 +15,18 @@ from .data_mapping import map_nfl_team
 class NFLAPIClient:
     """Client for a public NFL stats API."""
 
-    def __init__(self, base_url: Optional[str] = None):
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        rate_limit_interval: float = 1.0,
+        cache_timeout: int = 3600,
+    ):
         self.base_url = base_url or current_app.config.get(
             "NFL_API_BASE_URL", "https://api.nfl.com/v1"
         )
         self.session = requests.Session()
+        self.rate_limiter = RateLimiter(rate_limit_interval)
+        self.cache = SimpleCache(default_timeout=cache_timeout)
 
     def _get(self, endpoint: str, params: Optional[dict] = None):
         """Perform GET with retry and handle errors."""
@@ -30,6 +39,7 @@ class NFLAPIClient:
                 params=params,
                 timeout=10,
                 logger=logging.getLogger(__name__),
+                rate_limiter=self.rate_limiter,
             )
             try:
                 return resp.json()
@@ -45,8 +55,13 @@ class NFLAPIClient:
             return {}
 
     def get_teams(self):
+        cached = self.cache.get("teams")
+        if cached is not None:
+            return cached
         data = self._get("/teams")
-        return data.get("teams", [])
+        teams = data.get("teams", [])
+        self.cache.set("teams", teams)
+        return teams
 
     def get_player_stats(
         self, player_id: int, season: Optional[int] = None, group: str = "offense"

--- a/app/services/rate_limit.py
+++ b/app/services/rate_limit.py
@@ -1,0 +1,19 @@
+import threading
+import time
+
+class RateLimiter:
+    """Simple rate limiter enforcing a minimum interval between requests."""
+
+    def __init__(self, min_interval: float = 1.0):
+        self.min_interval = float(min_interval)
+        self._lock = threading.Lock()
+        self._last_time = 0.0
+
+    def wait(self) -> None:
+        """Block until it is OK to perform the next request."""
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_time
+            if elapsed < self.min_interval:
+                time.sleep(self.min_interval - elapsed)
+            self._last_time = time.monotonic()


### PR DESCRIPTION
## Summary
- implement `RateLimiter` helper for pausing between requests
- enhance `request_with_retry` to accept optional rate limiting
- add simple caching for team lists and schedules across sports
- update NBA, MLB, NFL and NHL API clients to support rate limiting and caching

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862e8cdd63c8327af0ed2a1d9e513ee