### PR TITLE
Add stat chart visualization

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/frontend/src/components/StatChart.jsx
+++ b/frontend/src/components/StatChart.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import 'chart.js/auto';
+
+export default function StatChart({ athleteId }) {
+  const [summary, setSummary] = useState(null);
+  const [statNames, setStatNames] = useState([]);
+  const [selected, setSelected] = useState('');
+
+  useEffect(() => {
+    if (!athleteId) return;
+    fetch(`/api/athletes/${athleteId}/stats/summary`)
+      .then((res) => res.json())
+      .then((data) => {
+        setSummary(data);
+        const names = new Set();
+        Object.values(data).forEach((stats) => {
+          Object.keys(stats).forEach((n) => names.add(n));
+        });
+        const arr = Array.from(names);
+        setStatNames(arr);
+        if (arr.length) setSelected(arr[0]);
+      })
+      .catch((err) => console.error('Failed to load stat summary', err));
+  }, [athleteId]);
+
+  if (!summary || !selected) return null;
+
+  const seasons = Object.keys(summary).sort();
+  const values = seasons.map((s) => Number(summary[s][selected]) || 0);
+
+  const data = {
+    labels: seasons,
+    datasets: [
+      {
+        label: selected,
+        data: values,
+        borderColor: '#007bff',
+        backgroundColor: 'rgba(0,123,255,0.5)',
+      },
+    ],
+  };
+
+  return (
+    <div className="stat-chart">
+      <h3>{selected} by Season</h3>
+      {statNames.length > 1 && (
+        <select value={selected} onChange={(e) => setSelected(e.target.value)}>
+          {statNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      )}
+      <Line data={data} />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,11 +33,6 @@ body {
 
 .profile-container h2 {
   margin-top: 0;
-=======
-.container {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 1rem;
 }
 
 .form-row {
@@ -79,4 +74,9 @@ body {
   justify-content: space-between;
   margin-bottom: 0.5rem;
 
+}
+
+.stat-chart {
+  max-width: 600px;
+  margin-top: 1rem;
 }

--- a/frontend/src/views/AthleteProfile.jsx
+++ b/frontend/src/views/AthleteProfile.jsx
@@ -2,6 +2,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import SkillEditor from '../components/SkillEditor';
 import StatEditor from '../components/StatEditor';
+import StatChart from '../components/StatChart';
 
 export default function AthleteProfile() {
   const { id } = useParams();
@@ -43,6 +44,7 @@ export default function AthleteProfile() {
       </div>
       <SkillEditor athleteId={id} />
       <StatEditor athleteId={id} />
+      <StatChart athleteId={id} />
     </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate Chart.js with new `StatChart` component
- show stat chart on athlete profile
- clean up CSS and add styles for charts
- include chart libraries in frontend dependencies

## Testing
- `pytest tests/test_stats_endpoints.py::test_stats_summary -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863df65ddd48327aad9f7056dcb09c9