### PR TITLE
Add multi-season stats table

### DIFF
--- a/frontend/src/components/SeasonStats.jsx
+++ b/frontend/src/components/SeasonStats.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+export default function SeasonStats({ athleteId }) {
+  const [summary, setSummary] = useState(null);
+
+  useEffect(() => {
+    if (!athleteId) return;
+    fetch(`/api/athletes/${athleteId}/stats/summary`)
+      .then((res) => res.json())
+      .then(setSummary)
+      .catch((err) => console.error('Failed to load stat summary', err));
+  }, [athleteId]);
+
+  if (!summary) return null;
+
+  const seasons = Object.keys(summary).sort();
+  const statNames = new Set();
+  seasons.forEach((season) => {
+    const stats = summary[season] || {};
+    Object.keys(stats).forEach((name) => statNames.add(name));
+  });
+  const columns = Array.from(statNames);
+
+  const highs = {};
+  columns.forEach((name) => {
+    let max = -Infinity;
+    seasons.forEach((season) => {
+      const value = parseFloat(summary[season][name]);
+      if (!isNaN(value) && value > max) {
+        max = value;
+      }
+    });
+    highs[name] = max;
+  });
+
+  return (
+    <div className="season-stats">
+      <h3>Season Totals</h3>
+      <table className="stat-table">
+        <thead>
+          <tr>
+            <th>Season</th>
+            {columns.map((name) => (
+              <th key={name}>{name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {seasons.map((season) => (
+            <tr key={season}>
+              <td>{season}</td>
+              {columns.map((name) => {
+                const value = summary[season][name];
+                const num = parseFloat(value);
+                const isHigh = !isNaN(num) && num === highs[name];
+                return (
+                  <td key={name} className={isHigh ? 'career-high' : undefined}>
+                    {value || '-'}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -80,3 +80,30 @@ body {
   max-width: 600px;
   margin-top: 1rem;
 }
+
+/* Season stats table */
+.season-stats {
+  margin-top: 1rem;
+}
+
+.stat-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.stat-table th,
+.stat-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.stat-table th {
+  background: #f0f0f0;
+}
+
+.career-high {
+  background-color: #ffecb3;
+  font-weight: bold;
+}

--- a/frontend/src/views/AthleteProfile.jsx
+++ b/frontend/src/views/AthleteProfile.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import SkillEditor from '../components/SkillEditor';
 import StatEditor from '../components/StatEditor';
 import StatChart from '../components/StatChart';
+import SeasonStats from '../components/SeasonStats';
 
 export default function AthleteProfile() {
   const { id } = useParams();
@@ -44,6 +45,7 @@ export default function AthleteProfile() {
       </div>
       <SkillEditor athleteId={id} />
       <StatEditor athleteId={id} />
+      <SeasonStats athleteId={id} />
       <StatChart athleteId={id} />
     </div>
     </div>


### PR DESCRIPTION
## Summary
- add `SeasonStats` React component for displaying player statistics per season
- include season stats table in the athlete profile view
- style the season stats table and highlight career highs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863e5d74ec88327a5d081080578168d