### PR TITLE
Add stats tab layout to profile

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -119,3 +119,26 @@ body {
   background-color: #ffecb3;
   font-weight: bold;
 }
+
+.stats-section {
+  margin-top: 1rem;
+}
+
+/* Stats tabs */
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #e0e0e0;
+  cursor: pointer;
+}
+
+.tab-button.active {
+  background: #007bff;
+  color: #fff;
+}

--- a/frontend/src/views/AthleteProfile.jsx
+++ b/frontend/src/views/AthleteProfile.jsx
@@ -10,6 +10,7 @@ export default function AthleteProfile() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [athlete, setAthlete] = useState(null);
+  const [statsTab, setStatsTab] = useState('summary');
 
   useEffect(() => {
     fetch(`/api/athletes/${id}`)
@@ -46,9 +47,33 @@ export default function AthleteProfile() {
       </div>
       <SkillEditor athleteId={id} />
       <StatEditor athleteId={id} />
-      <SeasonStats athleteId={id} />
-      <GameLog athleteId={id} />
-      <StatChart athleteId={id} />
+
+      <div className="stats-section">
+        <h3>Stats</h3>
+        <div className="tabs">
+          <button
+            className={`tab-button ${statsTab === 'summary' ? 'active' : ''}`}
+            onClick={() => setStatsTab('summary')}
+          >
+            Overview
+          </button>
+          <button
+            className={`tab-button ${statsTab === 'gameLog' ? 'active' : ''}`}
+            onClick={() => setStatsTab('gameLog')}
+          >
+            Game Log
+          </button>
+          <button
+            className={`tab-button ${statsTab === 'chart' ? 'active' : ''}`}
+            onClick={() => setStatsTab('chart')}
+          >
+            Charts
+          </button>
+        </div>
+        {statsTab === 'summary' && <SeasonStats athleteId={id} />}
+        {statsTab === 'gameLog' && <GameLog athleteId={id} />}
+        {statsTab === 'chart' && <StatChart athleteId={id} />}
+      </div>
     </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add tab navigation to stats on the athlete profile page
- style tabs in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6864501692808327985d30c201fa8bd0