### PR TITLE
Add vitest unit tests for new React components

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,14 @@ npm run dev
 
 The server proxies API requests to `http://localhost:5000` so make sure the Flask backend is running locally on port 5000.
 
+## Unit tests
+
+Vitest is used for component unit tests. After installing dependencies run:
+
+```bash
+npm run test
+```
+
 ## End-to-end tests
 
 Playwright tests are located in the `tests` directory. They spin up the Flask

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -17,6 +18,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.4"
   }
 }

--- a/frontend/src/components/SeasonStats.jsx
+++ b/frontend/src/components/SeasonStats.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { computeSeasonData } from '../utils/stats.js';
 
 export default function SeasonStats({ athleteId }) {
   const [summary, setSummary] = useState(null);
@@ -28,25 +29,7 @@ export default function SeasonStats({ athleteId }) {
   if (error) return <div style={{ color: 'red' }}>{error}</div>;
   if (!summary) return null;
 
-  const seasons = Object.keys(summary).sort();
-  const statNames = new Set();
-  seasons.forEach((season) => {
-    const stats = summary[season] || {};
-    Object.keys(stats).forEach((name) => statNames.add(name));
-  });
-  const columns = Array.from(statNames);
-
-  const highs = {};
-  columns.forEach((name) => {
-    let max = -Infinity;
-    seasons.forEach((season) => {
-      const value = parseFloat(summary[season][name]);
-      if (!isNaN(value) && value > max) {
-        max = value;
-      }
-    });
-    highs[name] = max;
-  });
+  const { seasons, columns, highs } = computeSeasonData(summary);
 
   return (
     <div className="season-stats">

--- a/frontend/src/utils/stats.js
+++ b/frontend/src/utils/stats.js
@@ -1,0 +1,21 @@
+export function computeSeasonData(summary) {
+  const seasons = Object.keys(summary || {}).sort();
+  const columns = new Set();
+  seasons.forEach((season) => {
+    const stats = summary[season] || {};
+    Object.keys(stats).forEach((name) => columns.add(name));
+  });
+  const cols = Array.from(columns);
+  const highs = {};
+  cols.forEach((name) => {
+    let max = -Infinity;
+    seasons.forEach((season) => {
+      const value = parseFloat(summary[season][name]);
+      if (!isNaN(value) && value > max) {
+        max = value;
+      }
+    });
+    highs[name] = max;
+  });
+  return { seasons, columns: cols, highs };
+}

--- a/frontend/tests/GameLog.test.jsx
+++ b/frontend/tests/GameLog.test.jsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameLog from '../src/components/GameLog.jsx';
+
+vi.stubGlobal('fetch', vi.fn());
+
+const summary = { '2023': {} };
+const page1 = { items: [
+  { game_id: 1, date: '2023-01-01', opponent_name: 'A', home_team_score: 1, visitor_team_score: 0 }
+], total: 6 };
+const page2 = { items: [
+  { game_id: 2, date: '2023-01-02', opponent_name: 'B', home_team_score: 2, visitor_team_score: 3 }
+], total: 6 };
+
+function queueResponses() {
+  fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(summary) });
+  fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(page1) });
+  fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(page2) });
+}
+
+describe('GameLog', () => {
+  it('paginates through games', async () => {
+    queueResponses();
+    render(<GameLog athleteId="1" />);
+    await waitFor(() => screen.getByText('A'));
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Next'));
+    await waitFor(() => screen.getByText('B'));
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/SeasonStats.test.jsx
+++ b/frontend/tests/SeasonStats.test.jsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import SeasonStats from '../src/components/SeasonStats.jsx';
+
+vi.stubGlobal('fetch', vi.fn());
+
+const summary = {
+  '2022': { points: '10', rebounds: '5' },
+  '2023': { points: '15', rebounds: '7' }
+};
+
+function mockSummary() {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(summary)
+  });
+}
+
+describe('SeasonStats', () => {
+  it('renders stats table with career highs highlighted', async () => {
+    mockSummary();
+    render(<SeasonStats athleteId="1" />);
+    await waitFor(() => screen.getByText('Season Totals'));
+    expect(screen.getByText('2022')).toBeInTheDocument();
+    expect(screen.getByText('2023')).toBeInTheDocument();
+    const highCell = screen.getAllByText('15')[0];
+    expect(highCell.classList.contains('career-high')).toBe(true);
+  });
+});

--- a/frontend/tests/StatChart.test.jsx
+++ b/frontend/tests/StatChart.test.jsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import StatChart from '../src/components/StatChart.jsx';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: ({ data }) => <div data-testid="chart">{JSON.stringify(data)}</div>
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+const summary = {
+  '2022': { points: '10' },
+  '2023': { points: '15' }
+};
+
+function mockSummary() {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(summary)
+  });
+}
+
+describe('StatChart', () => {
+  it('plots data points for selected stat', async () => {
+    mockSummary();
+    render(<StatChart athleteId="1" />);
+    await waitFor(() => screen.getByTestId('chart'));
+    const chart = screen.getByTestId('chart');
+    const chartData = JSON.parse(chart.textContent);
+    expect(chartData.labels).toEqual(['2022', '2023']);
+    expect(chartData.datasets[0].data).toEqual([10, 15]);
+  });
+});

--- a/frontend/tests/stats.test.jsx
+++ b/frontend/tests/stats.test.jsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { computeSeasonData } from '../src/utils/stats.js';
+
+const summary = {
+  '2022': { points: '10', rebounds: '5' },
+  '2023': { points: '15', rebounds: '7' }
+};
+
+describe('computeSeasonData', () => {
+  it('computes seasons, columns and highs', () => {
+    const result = computeSeasonData(summary);
+    expect(result.seasons).toEqual(['2022', '2023']);
+    expect(result.columns).toEqual(['points', 'rebounds']);
+    expect(result.highs.points).toBe(15);
+    expect(result.highs.rebounds).toBe(7);
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,5 +7,8 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:5000'
     }
+  },
+  test: {
+    environment: 'jsdom'
   }
 });


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library config
- implement `computeSeasonData` utility
- refactor `SeasonStats` to use new utility
- add unit tests for `SeasonStats`, `GameLog`, `StatChart` and utility
- document `npm run test` in frontend README

## Testing
- `npm run test` *(fails: vitest not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_6864a4377d44832785a66781b0e9920c