### PR TITLE
Extend stats schema

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,20 +4,21 @@ from .oauth import UserOAuthAccount
 from .sport import Sport, Position
 from .athlete import AthleteProfile
 from .media import AthleteMedia
-from .stats import AthleteStat
+from .stats import AthleteStat, SeasonStat, GameStat
 from .skill import AthleteSkill
 
 __all__ = [
     'User', 'Role', 'UserRole',
     'UserOAuthAccount', 'Sport', 'Position',
     'AthleteProfile', 'AthleteMedia', 'AthleteStat',
+    'SeasonStat', 'GameStat',
     'AthleteSkill',
 ]
 
-from .team import NBATeam, MLBTeam, NFLTeam, NHLTeam
-from .game import NBAGame, NHLGame
+from .team import Team, NBATeam, MLBTeam, NFLTeam, NHLTeam
+from .game import Game, NBAGame, NHLGame
 
-__all__.extend(['NBATeam', 'NBAGame', 'MLBTeam', 'NFLTeam', 'NHLTeam', 'NHLGame'])
+__all__.extend(['Team', 'Game', 'NBATeam', 'NBAGame', 'MLBTeam', 'NFLTeam', 'NHLTeam', 'NHLGame'])
 
 from .sync_log import SyncLog
 

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -1,6 +1,30 @@
 from app import db
 from app.models.base import BaseModel
 
+
+class Game(BaseModel):
+    """Generic game table supporting multiple sports."""
+
+    __tablename__ = 'games'
+
+    game_id = db.Column(db.Integer, primary_key=True)
+    sport_id = db.Column(
+        db.Integer, db.ForeignKey('sports.sport_id'), nullable=False
+    )
+    season = db.Column(db.String(10))
+    date = db.Column(db.Date)
+    home_team_id = db.Column(db.Integer, db.ForeignKey('teams.team_id'))
+    visitor_team_id = db.Column(db.Integer, db.ForeignKey('teams.team_id'))
+    home_team_score = db.Column(db.Integer)
+    visitor_team_score = db.Column(db.Integer)
+
+    sport = db.relationship('Sport')
+    home_team = db.relationship('Team', foreign_keys=[home_team_id], back_populates='games_home')
+    visitor_team = db.relationship('Team', foreign_keys=[visitor_team_id], back_populates='games_away')
+
+    def __repr__(self):
+        return f'<Game {self.game_id}>'
+
 class NBAGame(BaseModel):
     __tablename__ = 'nba_games'
 

--- a/app/models/stats.py
+++ b/app/models/stats.py
@@ -20,3 +20,55 @@ class AthleteStat(BaseModel):
 
     def __repr__(self):
         return f'<AthleteStat {self.stat_id}>'
+
+
+class SeasonStat(BaseModel):
+    """Aggregated stats for a player during a specific season."""
+
+    __tablename__ = 'season_stats'
+
+    season_stat_id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    athlete_id = db.Column(
+        db.String(36), db.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False
+    )
+    sport_id = db.Column(db.Integer, db.ForeignKey('sports.sport_id'), nullable=False)
+    team_id = db.Column(db.Integer, db.ForeignKey('teams.team_id'))
+    season = db.Column(db.String(10), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    value = db.Column(db.String(100))
+
+    athlete = db.relationship('AthleteProfile')
+    sport = db.relationship('Sport')
+    team = db.relationship('Team')
+
+    __table_args__ = (
+        db.Index('idx_season_stats_athlete', 'athlete_id'),
+        db.Index('idx_season_stats_season', 'season'),
+    )
+
+    def __repr__(self):
+        return f'<SeasonStat {self.season_stat_id}>'
+
+
+class GameStat(BaseModel):
+    """Per-game statistics for an athlete."""
+
+    __tablename__ = 'game_stats'
+
+    game_stat_id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    athlete_id = db.Column(
+        db.String(36), db.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False
+    )
+    game_id = db.Column(db.Integer, db.ForeignKey('games.game_id'), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    value = db.Column(db.String(100))
+
+    athlete = db.relationship('AthleteProfile')
+    game = db.relationship('Game')
+
+    __table_args__ = (
+        db.Index('idx_game_stats_game', 'game_id'),
+    )
+
+    def __repr__(self):
+        return f'<GameStat {self.game_stat_id}>'

--- a/app/models/team.py
+++ b/app/models/team.py
@@ -1,6 +1,32 @@
 from app import db
 from app.models.base import BaseModel
 
+
+class Team(BaseModel):
+    """Generic team table supporting multiple sports."""
+
+    __tablename__ = 'teams'
+
+    team_id = db.Column(db.Integer, primary_key=True)
+    sport_id = db.Column(
+        db.Integer, db.ForeignKey('sports.sport_id'), nullable=False
+    )
+    abbreviation = db.Column(db.String(10))
+    city = db.Column(db.String(100))
+    name = db.Column(db.String(100), nullable=False)
+    league = db.Column(db.String(50))
+
+    sport = db.relationship('Sport')
+    games_home = db.relationship(
+        'Game', back_populates='home_team', foreign_keys='Game.home_team_id'
+    )
+    games_away = db.relationship(
+        'Game', back_populates='visitor_team', foreign_keys='Game.visitor_team_id'
+    )
+
+    def __repr__(self):
+        return f'<Team {self.name}>'
+
 class NBATeam(BaseModel):
     __tablename__ = 'nba_teams'
 

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -42,3 +42,23 @@ Additional tables for NFL integration:
 ```
 nfl_teams (team_id PK)
 ```
+
+## Extended multi-sport stats schema
+
+To support historical statistics across NBA, MLB, NHL and NFL the following
+generic tables are introduced:
+
+```
+teams (team_id PK, sport_id FK -> sports.sport_id)
+  |--< games (game_id PK, sport_id FK -> sports.sport_id,
+             home_team_id FK -> teams.team_id,
+             visitor_team_id FK -> teams.team_id)
+  |      `--< game_stats (game_stat_id PK, game_id FK -> games.game_id,
+                         athlete_id FK -> athlete_profiles.athlete_id)
+  `--< season_stats (season_stat_id PK, team_id FK -> teams.team_id,
+                     athlete_id FK -> athlete_profiles.athlete_id)
+```
+
+`season_stats` stores aggregated values per athlete and season, while
+`game_stats` captures per-game lines.  Each record references the related
+sport and team so multi-season histories can be stored for different leagues.

--- a/migrations/versions/e6d6b9c8f7c9_add_generic_teams_and_stats_tables.py
+++ b/migrations/versions/e6d6b9c8f7c9_add_generic_teams_and_stats_tables.py
@@ -1,0 +1,87 @@
+"""add generic teams and stats tables
+
+Revision ID: e6d6b9c8f7c9
+Revises: abcd1234add
+Create Date: 2025-07-03 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e6d6b9c8f7c9'
+down_revision = 'abcd1234add'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'teams',
+        sa.Column('team_id', sa.Integer(), primary_key=True),
+        sa.Column('sport_id', sa.Integer(), sa.ForeignKey('sports.sport_id'), nullable=False),
+        sa.Column('abbreviation', sa.String(length=10)),
+        sa.Column('city', sa.String(length=100)),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('league', sa.String(length=50)),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('idx_teams_sport', 'teams', ['sport_id'])
+
+    op.create_table(
+        'games',
+        sa.Column('game_id', sa.Integer(), primary_key=True),
+        sa.Column('sport_id', sa.Integer(), sa.ForeignKey('sports.sport_id'), nullable=False),
+        sa.Column('season', sa.String(length=10)),
+        sa.Column('date', sa.Date()),
+        sa.Column('home_team_id', sa.Integer(), sa.ForeignKey('teams.team_id')),
+        sa.Column('visitor_team_id', sa.Integer(), sa.ForeignKey('teams.team_id')),
+        sa.Column('home_team_score', sa.Integer()),
+        sa.Column('visitor_team_score', sa.Integer()),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('idx_games_sport_season', 'games', ['sport_id', 'season'])
+
+    op.create_table(
+        'season_stats',
+        sa.Column('season_stat_id', sa.String(length=36), primary_key=True),
+        sa.Column('athlete_id', sa.String(length=36), sa.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False),
+        sa.Column('sport_id', sa.Integer(), sa.ForeignKey('sports.sport_id'), nullable=False),
+        sa.Column('team_id', sa.Integer(), sa.ForeignKey('teams.team_id')),
+        sa.Column('season', sa.String(length=10), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('value', sa.String(length=100)),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('idx_season_stats_athlete', 'season_stats', ['athlete_id'])
+    op.create_index('idx_season_stats_season', 'season_stats', ['season'])
+
+    op.create_table(
+        'game_stats',
+        sa.Column('game_stat_id', sa.String(length=36), primary_key=True),
+        sa.Column('athlete_id', sa.String(length=36), sa.ForeignKey('athlete_profiles.athlete_id', ondelete='CASCADE'), nullable=False),
+        sa.Column('game_id', sa.Integer(), sa.ForeignKey('games.game_id'), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('value', sa.String(length=100)),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('idx_game_stats_game', 'game_stats', ['game_id'])
+
+
+def downgrade():
+    op.drop_index('idx_game_stats_game', table_name='game_stats')
+    op.drop_table('game_stats')
+
+    op.drop_index('idx_season_stats_season', table_name='season_stats')
+    op.drop_index('idx_season_stats_athlete', table_name='season_stats')
+    op.drop_table('season_stats')
+
+    op.drop_index('idx_games_sport_season', table_name='games')
+    op.drop_table('games')
+
+    op.drop_index('idx_teams_sport', table_name='teams')
+    op.drop_table('teams')


### PR DESCRIPTION
## Summary
- add generic Team and Game models
- add SeasonStat and GameStat models
- create Alembic migration for the new tables
- document the extended multi-sport stats schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68654195f49483279455961412763647