### PR TITLE
Implement historical backfill job

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -66,3 +66,56 @@ def weekly_sync_player_stats():
         db.session.rollback()
         _log_sync("weekly_sync_player_stats", False, str(exc))
 
+
+def historical_backfill_stats(seasons=None, num_seasons: int = 3):
+    """Backfill historical stats for tracked athletes and teams."""
+    if seasons is None:
+        current_year = date.today().year
+        seasons = [current_year - i for i in range(num_seasons)]
+
+    try:
+        nba_client = nba_service.NBAAPIClient()
+        nfl_client = nfl_service.NFLAPIClient()
+        mlb_client = mlb_service.MLBAPIClient()
+        nhl_client = nhl_service.NHLAPIClient()
+
+        # ensure team lists exist
+        nba_service.sync_teams(nba_client)
+        nhl_service.sync_teams(nhl_client)
+        nfl_service.sync_teams(nfl_client)
+        mlb_service.sync_teams(mlb_client)
+
+        for season in seasons:
+            for team in NBATeam.query.all():
+                nba_service.sync_games(nba_client, team.team_id, season=season)
+            for team in NHLTeam.query.all():
+                nhl_service.sync_games(
+                    nhl_client, team.team_id, season=str(season)
+                )
+
+            for athlete in AthleteProfile.query.all():
+                sport = athlete.primary_sport.code if athlete.primary_sport else None
+                if sport == "NBA":
+                    nba_service.sync_player_stats(
+                        nba_client, athlete, season=season
+                    )
+                elif sport == "NFL":
+                    nfl_service.sync_player_stats(
+                        nfl_client, athlete, season=season
+                    )
+                elif sport == "MLB":
+                    mlb_service.sync_player_stats(
+                        mlb_client, athlete, season=season
+                    )
+                elif sport == "NHL":
+                    nhl_service.sync_player_stats(
+                        nhl_client, athlete, season=str(season)
+                    )
+
+        logger.info("Historical stats backfill complete for seasons %s", seasons)
+        _log_sync("historical_backfill_stats", True, f"seasons: {seasons}")
+    except Exception as exc:
+        logger.exception("Historical backfill failed: %s", exc)
+        db.session.rollback()
+        _log_sync("historical_backfill_stats", False, str(exc))
+

--- a/run.py
+++ b/run.py
@@ -278,5 +278,14 @@ def seed_demo():
     db.session.commit()
     click.echo('Demo athlete data created.')
 
+
+@app.cli.command('backfill-stats')
+@click.option('--seasons', default=3, type=int, help='Number of past seasons to backfill')
+@with_appcontext
+def backfill_stats_cmd(seasons: int):
+    """Backfill historical statistics for all athletes."""
+    from app import jobs
+    jobs.historical_backfill_stats(num_seasons=seasons)
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/tests/test_backfill_job.py
+++ b/tests/test_backfill_job.py
@@ -1,0 +1,68 @@
+from datetime import date
+
+import pytest
+
+from app import create_app, db, jobs
+from app.models import Sport, User, AthleteProfile, AthleteStat, NBATeam, SyncLog
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def app_ctx(app_instance):
+    with app_instance.app_context():
+        yield
+
+
+def test_historical_backfill(app_ctx, monkeypatch):
+    # Setup minimal sport and athlete
+    sport = Sport(name='Basketball', code='NBA')
+    db.session.add(sport)
+    db.session.commit()
+
+    user = User(username='u1', email='u1@example.com', first_name='f', last_name='l')
+    user.save()
+    athlete = AthleteProfile(
+        user_id=user.user_id,
+        primary_sport_id=sport.sport_id,
+        date_of_birth=date.fromisoformat('2000-01-01'),
+    )
+    athlete.nba_player_id = 23
+    athlete.save()
+
+    # Create team so sync_games loop has an entry
+    team = NBATeam(team_id=1, name='Lakers')
+    db.session.add(team)
+    db.session.commit()
+
+    # Dummy services
+    class DummyNBA:
+        def get_teams(self):
+            return []
+
+        def get_games(self, team_id, season=None):
+            return []
+
+        def get_player_season_avg(self, player_id, season=None):
+            return {'season': season, 'pts': 10, 'reb': 3, 'ast': 4}
+
+    monkeypatch.setattr(jobs.nba_service, 'NBAAPIClient', lambda: DummyNBA())
+    monkeypatch.setattr(jobs.nba_service, 'sync_teams', lambda client: None)
+    monkeypatch.setattr(jobs.nba_service, 'sync_games', lambda *a, **k: None)
+
+    jobs.historical_backfill_stats(seasons=[2023, 2024])
+
+    stats = AthleteStat.query.filter_by(athlete_id=athlete.athlete_id).all()
+    seasons = sorted([s.season for s in stats])
+    assert seasons == ['2023', '2024']
+    log = SyncLog.query.filter_by(job_name='historical_backfill_stats').first()
+    assert log and log.success


### PR DESCRIPTION
## Summary
- implement `historical_backfill_stats` job for multi-season imports
- expose the job via a `backfill-stats` CLI command
- add regression test for the new job

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686543fde4e88327908fdb80183025f4