### PR TITLE
Improve stat query performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Run database migrations to create all tables:
 flask db upgrade
 ```
 
+The latest migrations add indexes on stat tables for faster lookups. Run the
+above command whenever pulling new code to ensure these indexes exist.
+
 3. **Run the server**
    ```bash
    flask run

--- a/app/models/stats.py
+++ b/app/models/stats.py
@@ -16,6 +16,8 @@ class AthleteStat(BaseModel):
 
     __table_args__ = (
         db.Index('idx_stats_athlete', 'athlete_id'),
+        db.Index('idx_stats_season', 'season'),
+        db.Index('idx_stats_athlete_season', 'athlete_id', 'season'),
     )
 
     def __repr__(self):
@@ -44,6 +46,8 @@ class SeasonStat(BaseModel):
     __table_args__ = (
         db.Index('idx_season_stats_athlete', 'athlete_id'),
         db.Index('idx_season_stats_season', 'season'),
+        db.Index('idx_season_stats_team', 'team_id'),
+        db.Index('idx_season_stats_athlete_season', 'athlete_id', 'season'),
     )
 
     def __repr__(self):
@@ -68,6 +72,8 @@ class GameStat(BaseModel):
 
     __table_args__ = (
         db.Index('idx_game_stats_game', 'game_id'),
+        db.Index('idx_game_stats_athlete', 'athlete_id'),
+        db.Index('idx_game_stats_athlete_game', 'athlete_id', 'game_id'),
     )
 
     def __repr__(self):

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -62,3 +62,10 @@ teams (team_id PK, sport_id FK -> sports.sport_id)
 `season_stats` stores aggregated values per athlete and season, while
 `game_stats` captures per-game lines.  Each record references the related
 sport and team so multi-season histories can be stored for different leagues.
+
+Key indexes exist to speed up stat retrieval:
+
+* `athlete_stats`: `athlete_id`, `season`, and the combination
+  `(athlete_id, season)`.
+* `season_stats`: `athlete_id`, `season`, `team_id` and `(athlete_id, season)`.
+* `game_stats`: `game_id`, `athlete_id` and `(athlete_id, game_id)`.

--- a/migrations/versions/ad4f9e2cb98b_add_stat_indexes.py
+++ b/migrations/versions/ad4f9e2cb98b_add_stat_indexes.py
@@ -1,0 +1,37 @@
+"""add indexes for stat lookup
+
+Revision ID: ad4f9e2cb98b
+Revises: e6d6b9c8f7c9
+Create Date: 2025-07-10 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ad4f9e2cb98b'
+down_revision = 'e6d6b9c8f7c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('idx_stats_season', 'athlete_stats', ['season'])
+    op.create_index('idx_stats_athlete_season', 'athlete_stats', ['athlete_id', 'season'])
+
+    op.create_index('idx_season_stats_team', 'season_stats', ['team_id'])
+    op.create_index('idx_season_stats_athlete_season', 'season_stats', ['athlete_id', 'season'])
+
+    op.create_index('idx_game_stats_athlete', 'game_stats', ['athlete_id'])
+    op.create_index('idx_game_stats_athlete_game', 'game_stats', ['athlete_id', 'game_id'])
+
+
+def downgrade():
+    op.drop_index('idx_game_stats_athlete_game', table_name='game_stats')
+    op.drop_index('idx_game_stats_athlete', table_name='game_stats')
+
+    op.drop_index('idx_season_stats_athlete_season', table_name='season_stats')
+    op.drop_index('idx_season_stats_team', table_name='season_stats')
+
+    op.drop_index('idx_stats_athlete_season', table_name='athlete_stats')
+    op.drop_index('idx_stats_season', table_name='athlete_stats')

--- a/tests/test_query_performance.py
+++ b/tests/test_query_performance.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import time
+from datetime import date
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User, AthleteProfile, AthleteStat
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "perf.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def test_athlete_stats_query_speed(app_instance):
+    with app_instance.app_context():
+        user = User(username='perf', email='perf@example.com', first_name='P', last_name='T')
+        user.save()
+        athlete = AthleteProfile(user_id=user.user_id, date_of_birth=date.fromisoformat('2000-01-01'))
+        athlete.save()
+
+        # populate multiple seasons
+        for season in ['2023', '2024']:
+            for i in range(500):
+                stat = AthleteStat(
+                    athlete_id=athlete.athlete_id,
+                    name='points',
+                    value=str(i),
+                    season=season,
+                )
+                db.session.add(stat)
+        db.session.commit()
+
+        start = time.perf_counter()
+        stats = AthleteStat.query.filter_by(athlete_id=athlete.athlete_id, season='2024').all()
+        duration = time.perf_counter() - start
+
+        assert len(stats) == 500
+        assert duration < 0.1


### PR DESCRIPTION
## Summary
- add DB indexes on athlete stats, season stats, and game stats tables
- generate migration to create the new indexes
- document indexes in database schema and README
- add a performance test to ensure stat queries return quickly

## Testing
- `pytest -k query_performance -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865497f0ef48327b2a7a7361b4271ae