### PR TITLE
Add constraints for stats tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ flask db upgrade
 
 The latest migrations add indexes on stat tables for faster lookups. Run the
 above command whenever pulling new code to ensure these indexes exist.
+The July 15 migration also enforces unique season and game stats and
+checks that game scores are non-negative.
 
 3. **Run the server**
    ```bash

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -22,6 +22,11 @@ class Game(BaseModel):
     home_team = db.relationship('Team', foreign_keys=[home_team_id], back_populates='games_home')
     visitor_team = db.relationship('Team', foreign_keys=[visitor_team_id], back_populates='games_away')
 
+    __table_args__ = (
+        db.CheckConstraint('home_team_score >= 0', name='ck_game_home_score_non_negative'),
+        db.CheckConstraint('visitor_team_score >= 0', name='ck_game_visitor_score_non_negative'),
+    )
+
     def __repr__(self):
         return f'<Game {self.game_id}>'
 
@@ -38,6 +43,11 @@ class NBAGame(BaseModel):
 
     home_team = db.relationship('NBATeam', foreign_keys=[home_team_id], back_populates='games_home')
     visitor_team = db.relationship('NBATeam', foreign_keys=[visitor_team_id], back_populates='games_away')
+
+    __table_args__ = (
+        db.CheckConstraint('home_team_score >= 0', name='ck_nba_game_home_score_non_negative'),
+        db.CheckConstraint('visitor_team_score >= 0', name='ck_nba_game_visitor_score_non_negative'),
+    )
 
     def __repr__(self):
         return f'<NBAGame {self.game_id}>'
@@ -56,6 +66,11 @@ class NHLGame(BaseModel):
 
     home_team = db.relationship('NHLTeam', foreign_keys=[home_team_id], back_populates='games_home')
     visitor_team = db.relationship('NHLTeam', foreign_keys=[visitor_team_id], back_populates='games_away')
+
+    __table_args__ = (
+        db.CheckConstraint('home_team_score >= 0', name='ck_nhl_game_home_score_non_negative'),
+        db.CheckConstraint('visitor_team_score >= 0', name='ck_nhl_game_visitor_score_non_negative'),
+    )
 
     def __repr__(self):
         return f'<NHLGame {self.game_id}>'

--- a/app/models/stats.py
+++ b/app/models/stats.py
@@ -44,6 +44,12 @@ class SeasonStat(BaseModel):
     team = db.relationship('Team')
 
     __table_args__ = (
+        db.UniqueConstraint(
+            'athlete_id',
+            'season',
+            'name',
+            name='uq_season_stat_player_season_name',
+        ),
         db.Index('idx_season_stats_athlete', 'athlete_id'),
         db.Index('idx_season_stats_season', 'season'),
         db.Index('idx_season_stats_team', 'team_id'),
@@ -71,6 +77,12 @@ class GameStat(BaseModel):
     game = db.relationship('Game')
 
     __table_args__ = (
+        db.UniqueConstraint(
+            'athlete_id',
+            'game_id',
+            'name',
+            name='uq_game_stat_unique',
+        ),
         db.Index('idx_game_stats_game', 'game_id'),
         db.Index('idx_game_stats_athlete', 'athlete_id'),
         db.Index('idx_game_stats_athlete_game', 'athlete_id', 'game_id'),

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -69,3 +69,9 @@ Key indexes exist to speed up stat retrieval:
   `(athlete_id, season)`.
 * `season_stats`: `athlete_id`, `season`, `team_id` and `(athlete_id, season)`.
 * `game_stats`: `game_id`, `athlete_id` and `(athlete_id, game_id)`.
+
+Unique constraints prevent duplicate records:
+
+* `season_stats`: `(athlete_id, season, name)`
+* `game_stats`: `(athlete_id, game_id, name)`
+Scores in all game tables must be non-negative.

--- a/migrations/versions/9f0f0ca2bbdc_add_constraints_to_stats_tables.py
+++ b/migrations/versions/9f0f0ca2bbdc_add_constraints_to_stats_tables.py
@@ -1,0 +1,72 @@
+"""add constraints to stats and game tables
+
+Revision ID: 9f0f0ca2bbdc
+Revises: ad4f9e2cb98b
+Create Date: 2025-07-15 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '9f0f0ca2bbdc'
+down_revision = 'ad4f9e2cb98b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(
+        'uq_season_stat_player_season_name',
+        'season_stats',
+        ['athlete_id', 'season', 'name'],
+    )
+    op.create_unique_constraint(
+        'uq_game_stat_unique',
+        'game_stats',
+        ['athlete_id', 'game_id', 'name'],
+    )
+
+    op.create_check_constraint(
+        'ck_game_home_score_non_negative',
+        'games',
+        'home_team_score >= 0'
+    )
+    op.create_check_constraint(
+        'ck_game_visitor_score_non_negative',
+        'games',
+        'visitor_team_score >= 0'
+    )
+    op.create_check_constraint(
+        'ck_nba_game_home_score_non_negative',
+        'nba_games',
+        'home_team_score >= 0'
+    )
+    op.create_check_constraint(
+        'ck_nba_game_visitor_score_non_negative',
+        'nba_games',
+        'visitor_team_score >= 0'
+    )
+    op.create_check_constraint(
+        'ck_nhl_game_home_score_non_negative',
+        'nhl_games',
+        'home_team_score >= 0'
+    )
+    op.create_check_constraint(
+        'ck_nhl_game_visitor_score_non_negative',
+        'nhl_games',
+        'visitor_team_score >= 0'
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_nhl_game_visitor_score_non_negative', 'nhl_games', type_='check')
+    op.drop_constraint('ck_nhl_game_home_score_non_negative', 'nhl_games', type_='check')
+    op.drop_constraint('ck_nba_game_visitor_score_non_negative', 'nba_games', type_='check')
+    op.drop_constraint('ck_nba_game_home_score_non_negative', 'nba_games', type_='check')
+    op.drop_constraint('ck_game_visitor_score_non_negative', 'games', type_='check')
+    op.drop_constraint('ck_game_home_score_non_negative', 'games', type_='check')
+
+    op.drop_constraint('uq_game_stat_unique', 'game_stats', type_='unique')
+    op.drop_constraint('uq_season_stat_player_season_name', 'season_stats', type_='unique')
+

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import uuid
+from datetime import date
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import (
+    User,
+    AthleteProfile,
+    Sport,
+    Position,
+    Team,
+    SeasonStat,
+    NBAGame,
+)
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "constraints.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _create_athlete():
+    sport = Sport(name='Basketball', code='NBA')
+    db.session.add(sport)
+    db.session.commit()
+    position = Position(sport_id=sport.sport_id, name='Guard', code='G')
+    db.session.add(position)
+    db.session.commit()
+    user = User(
+        username=str(uuid.uuid4()),
+        email=f'{uuid.uuid4()}@example.com',
+        first_name='F',
+        last_name='L',
+    )
+    user.save()
+    athlete = AthleteProfile(
+        user_id=user.user_id,
+        primary_sport_id=sport.sport_id,
+        primary_position_id=position.position_id,
+        date_of_birth=date.fromisoformat('2000-01-01'),
+    )
+    athlete.save()
+    team = Team(team_id=1, sport_id=sport.sport_id, name='Lakers', abbreviation='LAL', city='LA')
+    db.session.add(team)
+    db.session.commit()
+    return athlete, sport, team
+
+
+def test_season_stats_unique_constraint(app_instance):
+    with app_instance.app_context():
+        athlete, sport, team = _create_athlete()
+        s1 = SeasonStat(
+            athlete_id=athlete.athlete_id,
+            sport_id=sport.sport_id,
+            team_id=team.team_id,
+            season='2024',
+            name='Points',
+            value='100',
+        )
+        db.session.add(s1)
+        db.session.commit()
+        s2 = SeasonStat(
+            athlete_id=athlete.athlete_id,
+            sport_id=sport.sport_id,
+            team_id=team.team_id,
+            season='2024',
+            name='Points',
+            value='120',
+        )
+        db.session.add(s2)
+        with pytest.raises(Exception):
+            db.session.commit()
+
+
+def test_game_score_check_constraint(app_instance):
+    with app_instance.app_context():
+        athlete, sport, team = _create_athlete()
+        game = NBAGame(
+            game_id=1,
+            date=date.fromisoformat('2024-01-01'),
+            season=2024,
+            home_team_id=team.team_id,
+            visitor_team_id=team.team_id,
+            home_team_score=-1,
+            visitor_team_score=90,
+        )
+        db.session.add(game)
+        with pytest.raises(Exception):
+            db.session.commit()
+


### PR DESCRIPTION
## Summary
- enforce unique season and game stat combinations
- require non-negative scores on all game tables
- add migration for new constraints
- document new constraints and update README
- test that constraints trigger integrity errors

## Testing
- `pytest -q tests/test_constraints.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68654d168dbc8327a12f600fe335b25c