### PR TITLE
Fix scheduler import loop

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,6 @@ from flask_migrate import Migrate
 from flask_login import LoginManager
 from authlib.integrations.flask_client import OAuth
 from config import config
-from .scheduler import init_scheduler
 
 # Initialize extensions
 db = SQLAlchemy()
@@ -43,6 +42,7 @@ def create_app(config_name='development'):
     app.register_blueprint(api_bp)
 
     if app.config.get('ENABLE_SCHEDULER'):
+        from .scheduler import init_scheduler
         init_scheduler(app)
     
     # User loader


### PR DESCRIPTION
## Summary
- move scheduler import to avoid circular import while creating app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68655085ce388327989947f905a1f95b