### PR TITLE
Secure dashboard with OAuth session

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,6 @@
 from flask import render_template
-from flask_login import login_required, current_user
+from flask_login import current_user
+from app.utils.auth import oauth_session_required
 from app.main import bp
 
 @bp.route('/')
@@ -8,7 +9,7 @@ def index():
     return render_template('main/index.html')
 
 @bp.route('/dashboard')
-@login_required
+@oauth_session_required
 def dashboard():
     """User dashboard"""
     return render_template('main/dashboard.html')

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -1,45 +1,44 @@
 {% extends "base.html" %}
 
-{% block content %}
-<h1>Welcome, {{ current_user.full_name }}!</h1>
+{% block title %}Dashboard - {{ super() }}{% endblock %}
 
-<div class="row mt-4">
-    <div class="col-md-3">
-        <div class="card bg-primary text-white">
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        <h1>Welcome{% if current_user.is_authenticated %}, {{ current_user.full_name }}{% endif %}!</h1>
+        <p class="lead">Your dashboard for managing athlete profiles and connections.</p>
+    </div>
+</div>
+
+{% if current_user.is_authenticated %}
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
             <div class="card-body">
-                <h5>Your Roles</h5>
-                {% for role in current_user.roles %}
-                    <span class="badge bg-light text-dark">{{ role.name }}</span>
-                {% endfor %}
+                <h5 class="card-title">User Information</h5>
+                <p><strong>Email:</strong> {{ current_user.email }}</p>
+                <p><strong>Status:</strong> {{ 'Active' if current_user.is_active else 'Inactive' }}</p>
+                <p><strong>Login Count:</strong> {{ current_user.login_count or 0 }}</p>
             </div>
         </div>
     </div>
     
-    <div class="col-md-3">
-        <div class="card bg-success text-white">
+    <div class="col-md-6">
+        <div class="card">
             <div class="card-body">
-                <h5>Status</h5>
-                <p>{{ 'Active' if current_user.is_active else 'Inactive' }}</p>
-            </div>
-        </div>
-    </div>
-    
-    <div class="col-md-3">
-        <div class="card bg-info text-white">
-            <div class="card-body">
-                <h5>Last Login</h5>
-                <p>{{ current_user.last_login.strftime('%Y-%m-%d %H:%M') if current_user.last_login else 'First time!' }}</p>
-            </div>
-        </div>
-    </div>
-    
-    <div class="col-md-3">
-        <div class="card bg-warning text-white">
-            <div class="card-body">
-                <h5>Login Count</h5>
-                <p>{{ current_user.login_count or 0 }}</p>
+                <h5 class="card-title">Quick Actions</h5>
+                <ul class="list-unstyled">
+                    <li><a href="#" class="text-decoration-none">Edit Profile</a></li>
+                    <li><a href="#" class="text-decoration-none">Account Settings</a></li>
+                    <li><a href="#" class="text-decoration-none">Privacy Settings</a></li>
+                </ul>
             </div>
         </div>
     </div>
 </div>
+{% else %}
+<div class="alert alert-info">
+    Please <a href="{{ url_for('auth.login') }}">login</a> to access your dashboard.
+</div>
+{% endif %}
 {% endblock %}

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from flask import request, abort
+from flask import request, abort, session, redirect, url_for, flash
 from flask_login import current_user, login_user
 from app.models.oauth import UserOAuthAccount
 
@@ -23,6 +23,19 @@ def login_or_token_required(fn):
                 return fn(*args, **kwargs)
 
         abort(401)
+
+    return wrapper
+
+
+def oauth_session_required(fn):
+    """Require an authenticated user with an OAuth session token."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not current_user.is_authenticated or not session.get('auth_token'):
+            flash('Please log in to access this page.', 'warning')
+            return redirect(url_for('auth.login'))
+        return fn(*args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
## Summary
- require OAuth session token for dashboard access
- show provided dashboard mockup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686557eb812883279d0cf10552c1850b