### PR TITLE
Add homepage search form functionality

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -61,6 +61,12 @@ body {
     border-radius: 50%;
 }
 
+/* Homepage search section */
+.search-section {
+    max-width: 600px;
+    margin: 0 auto 2rem;
+}
+
 /* Glassy navbar style */
 .navbar-glass {
     backdrop-filter: blur(6px);

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,37 @@
+// Simple search form handler for the homepage
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('homepage-search');
+  if (!form) return;
+
+  const input = document.getElementById('search-query');
+  const button = document.getElementById('search-submit');
+  const results = document.getElementById('search-results');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const query = input.value.trim();
+    if (!query) return;
+
+    const original = button.textContent;
+    button.textContent = 'Searching…';
+    button.disabled = true;
+
+    try {
+      const res = await fetch(`/api/athletes/search?q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      results.innerHTML = '';
+      (data.results || []).forEach((ath) => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = ath.user.full_name;
+        results.appendChild(li);
+      });
+    } catch (err) {
+      console.error('Search failed', err);
+    } finally {
+      button.textContent = original;
+      button.disabled = false;
+    }
+  });
+});

--- a/templates/main/base.html
+++ b/templates/main/base.html
@@ -7,6 +7,7 @@
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet">
     
     {% block head %}{% endblock %}
 </head>

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -11,6 +11,14 @@
     {% endif %}
 </div>
 
+<div class="search-section text-center my-4">
+    <form id="homepage-search" class="d-flex justify-content-center">
+        <input type="text" id="search-query" class="form-control form-control-lg me-2" placeholder="Search athletes...">
+        <button type="submit" id="search-submit" class="btn btn-secondary btn-lg">Search</button>
+    </form>
+    <ul id="search-results" class="list-group w-50 mx-auto mt-3"></ul>
+</div>
+
 <div class="row">
     <div class="col-md-4">
         <div class="card h-100">
@@ -39,4 +47,8 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/search.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add search form markup to homepage and include search JS
- style search section in CSS
- load custom CSS in base template
- implement client-side search with temporary loading state

## Testing
- `pytest -q` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68658e40745083278c47f7f44abbe114