### PR TITLE
Add filter support to athlete search

### DIFF
--- a/app/models/athlete.py
+++ b/app/models/athlete.py
@@ -33,6 +33,7 @@ class AthleteProfile(BaseModel):
     years_professional = db.Column(db.Integer)
     current_team = db.Column(db.String(100))
     jersey_number = db.Column(db.String(5))
+    contract_active = db.Column(db.Boolean, default=True)
     
     # Profile information
     bio = db.Column(db.Text)

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -33,4 +33,4 @@ All API routes are prefixed with `/api`. Authentication is required for endpoint
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| GET | `/api/athletes/search` | Search athletes using query parameters such as `q`, `sport`, `position`, `team`, age/height/weight filters. |
+| GET | `/api/athletes/search` | Search athletes using query parameters such as `q`, `sport`, `position`, `team`, age/height/weight filters and the `filter` tab (nba, nfl, mlb, nhl, available, top). |

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -1,0 +1,76 @@
+import uuid
+import json
+from datetime import date
+import pytest
+
+from app import create_app, db
+from app.models import User, AthleteProfile, Sport
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def create_athlete(code, rating=50, contract=True):
+    sport = Sport.query.filter_by(code=code).first()
+    if not sport:
+        sport = Sport(name=code, code=code)
+        db.session.add(sport)
+        db.session.commit()
+    user = User(username=str(uuid.uuid4()), email=f'{uuid.uuid4()}@ex.com', first_name='F', last_name='L')
+    user.save()
+    athlete = AthleteProfile(
+        user_id=user.user_id,
+        primary_sport_id=sport.sport_id,
+        date_of_birth=date.fromisoformat('2000-01-01'),
+        overall_rating=rating,
+        contract_active=contract,
+    )
+    athlete.save()
+    return athlete
+
+
+def test_filter_league(client, app_instance):
+    with app_instance.app_context():
+        a_nba = create_athlete('NBA')
+        create_athlete('NFL')
+
+    resp = client.get('/api/athletes/search?filter=nba')
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data['count'] == 1
+    assert data['results'][0]['athlete_id'] == a_nba.athlete_id
+
+
+def test_filter_available(client, app_instance):
+    with app_instance.app_context():
+        create_athlete('NBA', contract=True)
+        a_free = create_athlete('NBA', contract=False)
+
+    resp = client.get('/api/athletes/search?filter=available')
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data['count'] == 1
+    assert data['results'][0]['athlete_id'] == a_free.athlete_id
+
+
+def test_filter_top_limit(client, app_instance):
+    with app_instance.app_context():
+        for i in range(15):
+            create_athlete('NBA', rating=99 - i)
+
+    resp = client.get('/api/athletes/search?filter=top')
+    data = json.loads(resp.data)
+    assert resp.status_code == 200
+    assert data['count'] == 10
+


### PR DESCRIPTION
## Summary
- support filter tab parameter in athlete search
- store contract status on AthleteProfile
- document search filter options
- test search filter logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865934ee9fc8327b882807e6f6b36e9