### PR TITLE
Add filter tab search hook

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -7,6 +7,35 @@ document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('search-query');
   const button = document.getElementById('search-submit');
   const results = document.getElementById('search-results');
+  const tabs = document.querySelectorAll('#filter-tabs .nav-link');
+  const featured = document.getElementById('featured-list');
+
+  async function runSearch(params) {
+    const res = await fetch(`/api/athletes/search?${params.toString()}`);
+    const data = await res.json();
+    return data.results || [];
+  }
+
+  async function renderFeatured(filter) {
+    if (!featured) return;
+    const params = new URLSearchParams();
+    if (filter) {
+      const f = filter.toLowerCase();
+      if (['nba', 'nfl', 'mlb', 'nhl'].includes(f)) {
+        params.append('sport', f.toUpperCase());
+      } else {
+        params.append('filter', f);
+      }
+    }
+    const athletes = await runSearch(params);
+    featured.innerHTML = '';
+    athletes.forEach((ath) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      li.textContent = ath.user.full_name;
+      featured.appendChild(li);
+    });
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -18,10 +47,11 @@ document.addEventListener('DOMContentLoaded', () => {
     button.disabled = true;
 
     try {
-      const res = await fetch(`/api/athletes/search?q=${encodeURIComponent(query)}`);
-      const data = await res.json();
+      const params = new URLSearchParams();
+      params.append('q', query);
+      const athletes = await runSearch(params);
       results.innerHTML = '';
-      (data.results || []).forEach((ath) => {
+      athletes.forEach((ath) => {
         const li = document.createElement('li');
         li.className = 'list-group-item';
         li.textContent = ath.user.full_name;
@@ -34,4 +64,18 @@ document.addEventListener('DOMContentLoaded', () => {
       button.disabled = false;
     }
   });
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', (e) => {
+      e.preventDefault();
+      tabs.forEach((t) => t.classList.remove('active'));
+      tab.classList.add('active');
+      renderFeatured(tab.dataset.filter);
+    });
+  });
+
+  const activeTab = document.querySelector('#filter-tabs .nav-link.active');
+  if (activeTab) {
+    renderFeatured(activeTab.dataset.filter);
+  }
 });

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -19,6 +19,19 @@
     <ul id="search-results" class="list-group w-50 mx-auto mt-3"></ul>
 </div>
 
+<div class="featured-container my-4">
+    <h2 class="text-center mb-3">Featured Athletes</h2>
+    <ul id="filter-tabs" class="nav nav-pills justify-content-center mb-3">
+        <li class="nav-item"><button class="nav-link active" data-filter="top">Top</button></li>
+        <li class="nav-item"><button class="nav-link" data-filter="NBA">NBA</button></li>
+        <li class="nav-item"><button class="nav-link" data-filter="NFL">NFL</button></li>
+        <li class="nav-item"><button class="nav-link" data-filter="MLB">MLB</button></li>
+        <li class="nav-item"><button class="nav-link" data-filter="NHL">NHL</button></li>
+        <li class="nav-item"><button class="nav-link" data-filter="available">Available</button></li>
+    </ul>
+    <ul id="featured-list" class="list-group w-50 mx-auto"></ul>
+</div>
+
 <div class="row">
     <div class="col-md-4">
         <div class="card h-100">


### PR DESCRIPTION
## Summary
- show filter tabs on the homepage
- hook filter tab clicks to the athlete search API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686595b5d1308327be28b0df791d91ec