### PR TITLE
Add search and filter combination test

### DIFF
--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -74,3 +74,17 @@ def test_filter_top_limit(client, app_instance):
     assert resp.status_code == 200
     assert data['count'] == 10
 
+
+def test_filter_and_search_combined(client, app_instance):
+    """Filter tab should work together with text search."""
+    with app_instance.app_context():
+        a_nba = create_athlete('NBA')
+        create_athlete('NFL')
+
+    resp = client.get('/api/athletes/search?filter=nba&q=F')
+    data = json.loads(resp.data)
+
+    assert resp.status_code == 200
+    assert data['count'] == 1
+    assert data['results'][0]['athlete_id'] == a_nba.athlete_id
+


### PR DESCRIPTION
## Summary
- ensure filter tabs combine properly with text search

## Testing
- `PYTHONPATH=. pytest tests/test_search_filters.py::test_filter_and_search_combined -q` *(fails: ModuleNotFoundError - flask)*

------
https://chatgpt.com/codex/tasks/task_e_68659a471de08327ae4af3f14ec0cb81