### PR TITLE
Preserve search state after AJAX queries

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template
+from flask import render_template, request
 from flask_login import current_user
 from app.utils.auth import oauth_session_required
 from app.main import bp
@@ -7,7 +7,14 @@ from app.main import bp
 def index():
     """Home page"""
     user_name = current_user.full_name if current_user.is_authenticated else None
-    return render_template('main/index.html', user_name=user_name)
+    search_query = request.args.get('q', '')
+    active_filter = request.args.get('filter', '')
+    return render_template(
+        'main/index.html',
+        user_name=user_name,
+        search_query=search_query,
+        active_filter=active_filter,
+    )
 
 @bp.route('/dashboard')
 @oauth_session_required

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -9,7 +9,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const results = document.getElementById('search-results');
   const tabs = document.querySelectorAll('#filter-tabs .nav-link');
   const featured = document.getElementById('featured-grid');
-  let activeFilter = document.querySelector('#filter-tabs .nav-link.active')?.dataset.filter || '';
+  const urlParams = new URLSearchParams(window.location.search);
+  let activeFilter = urlParams.get('filter') || document.querySelector('#filter-tabs .nav-link.active')?.dataset.filter || '';
+  if (urlParams.get('q')) {
+    input.value = urlParams.get('q');
+  }
+
+  function updateURL() {
+    const params = new URLSearchParams();
+    const q = input.value.trim();
+    if (q) params.set('q', q);
+    if (activeFilter) params.set('filter', activeFilter);
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState({}, '', newUrl);
+  }
 
   function createCard(ath) {
     const col = document.createElement('div');
@@ -90,6 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     try {
       await updateFeatured();
+      updateURL();
     } catch (err) {
       console.error('Search failed', err);
     } finally {
@@ -105,12 +119,20 @@ document.addEventListener('DOMContentLoaded', () => {
       tab.classList.add('active');
       activeFilter = tab.dataset.filter;
       updateFeatured();
+      updateURL();
     });
   });
 
-  const activeTab = document.querySelector('#filter-tabs .nav-link.active');
-  if (activeTab) {
-    activeFilter = activeTab.dataset.filter;
+  if (activeFilter) {
+    tabs.forEach((t) => {
+      if (t.dataset.filter === activeFilter) {
+        tabs.forEach((el) => el.classList.remove('active'));
+        t.classList.add('active');
+      }
+    });
+  }
+
+  if (urlParams.get('q') || activeFilter) {
     updateFeatured();
   }
 });

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -13,7 +13,7 @@
 
 <div class="search-section text-center my-4">
     <form id="homepage-search" class="d-flex justify-content-center">
-        <input type="text" id="search-query" class="form-control form-control-lg me-2" placeholder="Search athletes...">
+        <input type="text" id="search-query" class="form-control form-control-lg me-2" placeholder="Search athletes..." value="{{ search_query }}">
         <button type="submit" id="search-submit" class="btn btn-secondary btn-lg">Search</button>
     </form>
     <ul id="search-results" class="list-group w-50 mx-auto mt-3"></ul>
@@ -22,12 +22,12 @@
 <div class="featured-container my-4">
     <h2 class="text-center mb-3">Featured Athletes</h2>
     <ul id="filter-tabs" class="nav nav-pills justify-content-center mb-3">
-        <li class="nav-item"><button class="nav-link active" data-filter="top">Top</button></li>
-        <li class="nav-item"><button class="nav-link" data-filter="NBA">NBA</button></li>
-        <li class="nav-item"><button class="nav-link" data-filter="NFL">NFL</button></li>
-        <li class="nav-item"><button class="nav-link" data-filter="MLB">MLB</button></li>
-        <li class="nav-item"><button class="nav-link" data-filter="NHL">NHL</button></li>
-        <li class="nav-item"><button class="nav-link" data-filter="available">Available</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|default('top')|lower == 'top' %} active{% endif %}" data-filter="top">Top</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|lower == 'nba' %} active{% endif %}" data-filter="NBA">NBA</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|lower == 'nfl' %} active{% endif %}" data-filter="NFL">NFL</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|lower == 'mlb' %} active{% endif %}" data-filter="MLB">MLB</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|lower == 'nhl' %} active{% endif %}" data-filter="NHL">NHL</button></li>
+        <li class="nav-item"><button class="nav-link{% if active_filter|lower == 'available' %} active{% endif %}" data-filter="available">Available</button></li>
     </ul>
     <div id="featured-grid" class="athlete-grid row row-cols-1 row-cols-md-3 g-4"></div>
 </div>


### PR DESCRIPTION
## Summary
- allow `index` route to read `q` and `filter` query params
- pre-populate homepage search input and filter tabs based on those params
- update `search.js` to sync search state with the URL so the active tab and text persist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68659db911dc832795697b42d0203de0