### PR TITLE
Add migration for contract_active column

### DIFF
--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -26,6 +26,11 @@ athlete_profiles
 
 Each `AthleteProfile` record is associated with exactly one `User`. Media, stats and skills reference the athlete profile via foreign keys. Sports have many positions, and each athlete is linked to a sport and position.
 
+Key fields on `athlete_profiles` include:
+
+* `contract_active` – indicates if the athlete currently has an active team contract.
+* `created_at` – timestamp when the profile was first created.
+
 Additional tables for NBA integration:
 
 ```

--- a/migrations/versions/b183ac0d37f0_add_contract_active.py
+++ b/migrations/versions/b183ac0d37f0_add_contract_active.py
@@ -1,0 +1,25 @@
+"""Add contract_active column to athlete_profiles
+
+Revision ID: b183ac0d37f0
+Revises: 9f0f0ca2bbdc
+Create Date: 2025-07-22 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b183ac0d37f0'
+down_revision = '9f0f0ca2bbdc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('athlete_profiles') as batch_op:
+        batch_op.add_column(sa.Column('contract_active', sa.Boolean(), server_default=sa.text('true')))
+
+
+def downgrade():
+    with op.batch_alter_table('athlete_profiles') as batch_op:
+        batch_op.drop_column('contract_active')


### PR DESCRIPTION
## Summary
- add `contract_active` column via new Alembic migration
- document important athlete profile fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68659fee7ad48327b0532e15a1e078b0