### PR TITLE
Add total athletes count to dashboard

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,8 @@
 from flask import render_template, request
 from flask_login import current_user
+from sqlalchemy import func
+from app import db
+from app.models import AthleteProfile
 from app.utils.auth import oauth_session_required
 from app.main import bp
 
@@ -21,4 +24,13 @@ def index():
 def dashboard():
     """User dashboard"""
     user_name = current_user.full_name
-    return render_template('main/dashboard.html', user_name=user_name)
+    total_athletes = (
+        db.session.query(func.count(AthleteProfile.athlete_id))
+        .filter(AthleteProfile.is_deleted.is_(False))
+        .scalar()
+    )
+    return render_template(
+        'main/dashboard.html',
+        user_name=user_name,
+        total_athletes=total_athletes,
+    )

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -36,6 +36,17 @@
         </div>
     </div>
 </div>
+
+<div class="row mt-4">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Total Athletes</h5>
+                <p class="display-6">{{ total_athletes }}</p>
+            </div>
+        </div>
+    </div>
+</div>
 {% else %}
 <div class="alert alert-info">
     Please <a href="{{ url_for('auth.login') }}">login</a> to access your dashboard.


### PR DESCRIPTION
## Summary
- show a Total Athletes card on the dashboard
- count current athletes with a single query in the dashboard route

## Testing
- `pytest -q` *(fails: environment setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6865a287fb5c8327a55432748c446fac