### PR TITLE
Add active contracts metric to dashboard

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -29,8 +29,17 @@ def dashboard():
         .filter(AthleteProfile.is_deleted.is_(False))
         .scalar()
     )
+    active_contracts = (
+        db.session.query(func.count(AthleteProfile.athlete_id))
+        .filter(
+            AthleteProfile.is_deleted.is_(False),
+            AthleteProfile.contract_active.is_(True),
+        )
+        .scalar()
+    )
     return render_template(
         'main/dashboard.html',
         user_name=user_name,
         total_athletes=total_athletes,
+        active_contracts=active_contracts,
     )

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -46,6 +46,14 @@
             </div>
         </div>
     </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Active Contracts</h5>
+                <p class="display-6">{{ active_contracts }}</p>
+            </div>
+        </div>
+    </div>
 </div>
 {% else %}
 <div class="alert alert-info">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import uuid
+from datetime import date
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User, Role, AthleteProfile
+
+@pytest.fixture
+def app_instance():
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        if not Role.query.filter_by(name='viewer').first():
+            db.session.add(Role(name='viewer'))
+            db.session.commit()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def _create_athlete(active=True):
+    user = User(username=str(uuid.uuid4()), email=f'{uuid.uuid4()}@example.com', first_name='F', last_name='L')
+    user.save()
+    athlete = AthleteProfile(
+        user_id=user.user_id,
+        date_of_birth=date.fromisoformat('2000-01-01'),
+        contract_active=active,
+    )
+    athlete.save()
+    return athlete
+
+
+def test_dashboard_active_contracts(client, app_instance):
+    # create sample athletes
+    _create_athlete(active=True)
+    _create_athlete(active=True)
+    _create_athlete(active=False)
+
+    # create and login user
+    with app_instance.app_context():
+        user = User(username='dashuser', email='dash@example.com', first_name='Dash', last_name='User')
+        user.set_password('secret')
+        role = Role.query.filter_by(name='viewer').first()
+        if role:
+            user.roles.append(role)
+        db.session.add(user)
+        db.session.commit()
+
+    client.post('/auth/login', data={'username_or_email': 'dashuser', 'password': 'secret'}, follow_redirects=True)
+    with client.session_transaction() as sess:
+        sess['auth_token'] = 'token'
+
+    resp = client.get('/dashboard')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'Active Contracts' in html
+    assert '>2<' in html
+


### PR DESCRIPTION
## Summary
- compute active athlete contracts on the dashboard
- display Active Contracts stat card
- test dashboard active contract count

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865a44f2be88327aa95b08dc37ab621