### PR TITLE
Add placeholder client satisfaction metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ Additional technical documentation is available in the `docs/` directory:
 - `database_schema.md` – overview of the database tables and relationships
 - `api_endpoints.md` – list of API endpoints with parameters
 - `user_guide_athletes.md` – instructions for managing athlete profiles
+
+The dashboard also shows a **Client Satisfaction** percentage. This metric is a
+placeholder value (set to 98.7%) for the demo. In Phase 3 the client may provide
+a formula or survey data to calculate it dynamically.

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, request
+from flask import render_template, request, current_app
 from flask_login import current_user
 from sqlalchemy import func
 from datetime import datetime, timedelta
@@ -46,10 +46,12 @@ def dashboard():
         )
         .scalar()
     )
+    client_satisfaction = current_app.config.get('CLIENT_SATISFACTION_PERCENT', 98.7)
     return render_template(
         'main/dashboard.html',
         user_name=user_name,
         total_athletes=total_athletes,
         active_contracts=active_contracts,
         new_this_week=new_this_week,
+        client_satisfaction=client_satisfaction,
     )

--- a/app/templates/main/dashboard.html
+++ b/app/templates/main/dashboard.html
@@ -38,7 +38,7 @@
 </div>
 
 <div class="row mt-4">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">Total Athletes</h5>
@@ -46,7 +46,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">Active Contracts</h5>
@@ -54,11 +54,19 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">New This Week</h5>
                 <p class="display-6">{{ new_this_week }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Client Satisfaction</h5>
+                <p class="display-6">{{ client_satisfaction }}%</p>
             </div>
         </div>
     </div>

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ class Config:
     NBA_API_TOKEN = os.environ.get("NBA_API_TOKEN")
     NFL_API_BASE_URL = os.environ.get("NFL_API_BASE_URL") or "https://api.nfl.com/v1"
     NHL_API_BASE_URL = os.environ.get("NHL_API_BASE_URL") or "https://statsapi.web.nhl.com/api/v1"
+    CLIENT_SATISFACTION_PERCENT = float(os.environ.get('CLIENT_SATISFACTION_PERCENT', '98.7'))
     ENABLE_SCHEDULER = os.environ.get('ENABLE_SCHEDULER', 'false').lower() == 'true'
 
 class DevelopmentConfig(Config):

--- a/docs/phase3_notes.md
+++ b/docs/phase3_notes.md
@@ -1,0 +1,5 @@
+# Phase 3 Placeholder Metrics
+
+The "Client Satisfaction" percentage displayed on the dashboard is currently hard-coded. It is intended as a placeholder metric for demonstration purposes.
+
+In a future phase the client may provide survey data or a formula for calculating this value dynamically. The implementation should be revisited when those requirements are clarified.

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -38,7 +38,7 @@
 </div>
 
 <div class="row mt-4">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">Total Athletes</h5>
@@ -46,7 +46,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">Active Contracts</h5>
@@ -54,11 +54,19 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">New This Week</h5>
                 <p class="display-6">{{ new_this_week }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Client Satisfaction</h5>
+                <p class="display-6">{{ client_satisfaction }}%</p>
             </div>
         </div>
     </div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -91,3 +91,24 @@ def test_dashboard_new_this_week(client, app_instance):
     assert 'New This Week' in html
     assert '>2<' in html
 
+
+def test_dashboard_client_satisfaction(client, app_instance):
+    with app_instance.app_context():
+        user = User(username='clientuser', email='client@example.com', first_name='Client', last_name='User')
+        user.set_password('secret')
+        role = Role.query.filter_by(name='viewer').first()
+        if role:
+            user.roles.append(role)
+        db.session.add(user)
+        db.session.commit()
+
+    client.post('/auth/login', data={'username_or_email': 'clientuser', 'password': 'secret'}, follow_redirects=True)
+    with client.session_transaction() as sess:
+        sess['auth_token'] = 'token'
+
+    resp = client.get('/dashboard')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'Client Satisfaction' in html
+    assert '98.7%' in html
+


### PR DESCRIPTION
## Summary
- show new placeholder Client Satisfaction card on dashboard
- make the percentage configurable via `CLIENT_SATISFACTION_PERCENT`
- test dashboard displays the new metric
- document placeholder metric in README and Phase 3 notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865ea9544748327b3d64deb05de7f0c