### PR TITLE
Improve dashboard stat formatting

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -29,6 +29,7 @@ def dashboard():
         db.session.query(func.count(AthleteProfile.athlete_id))
         .filter(AthleteProfile.is_deleted.is_(False))
         .scalar()
+        or 0
     )
     active_contracts = (
         db.session.query(func.count(AthleteProfile.athlete_id))
@@ -37,6 +38,7 @@ def dashboard():
             AthleteProfile.contract_active.is_(True),
         )
         .scalar()
+        or 0
     )
     new_this_week = (
         db.session.query(func.count(AthleteProfile.athlete_id))
@@ -45,8 +47,17 @@ def dashboard():
             AthleteProfile.created_at >= datetime.utcnow() - timedelta(days=7),
         )
         .scalar()
+        or 0
     )
-    client_satisfaction = current_app.config.get('CLIENT_SATISFACTION_PERCENT', 98.7)
+
+    raw_satisfaction = current_app.config.get('CLIENT_SATISFACTION_PERCENT', 98.7)
+    try:
+        satisfaction_value = float(raw_satisfaction)
+    except (TypeError, ValueError):
+        satisfaction_value = 0.0
+    if satisfaction_value <= 1.0:
+        satisfaction_value *= 100
+    client_satisfaction = f"{satisfaction_value:.1f}"
     return render_template(
         'main/dashboard.html',
         user_name=user_name,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,6 +40,21 @@ def _create_athlete(active=True, created_at=None):
     return athlete
 
 
+def _create_and_login_user(client, app_instance, username):
+    with app_instance.app_context():
+        user = User(username=username, email=f'{username}@example.com', first_name='Test', last_name='User')
+        user.set_password('secret')
+        role = Role.query.filter_by(name='viewer').first()
+        if role:
+            user.roles.append(role)
+        db.session.add(user)
+        db.session.commit()
+    client.post('/auth/login', data={'username_or_email': username, 'password': 'secret'}, follow_redirects=True)
+    with client.session_transaction() as sess:
+        sess['auth_token'] = 'token'
+    return user
+
+
 def test_dashboard_active_contracts(client, app_instance):
     # create sample athletes
     _create_athlete(active=True)
@@ -110,5 +125,55 @@ def test_dashboard_client_satisfaction(client, app_instance):
     assert resp.status_code == 200
     html = resp.data.decode()
     assert 'Client Satisfaction' in html
+    assert '98.7%' in html
+
+
+def test_dashboard_total_counts(client, app_instance):
+    """Total athletes and active contracts should show correct numbers."""
+    with app_instance.app_context():
+        for _ in range(8):
+            _create_athlete(active=True)
+        for _ in range(2):
+            _create_athlete(active=False)
+
+    _create_and_login_user(client, app_instance, 'countuser')
+
+    resp = client.get('/dashboard')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'Total Athletes' in html
+    assert '>10<' in html
+    assert '>8<' in html
+
+
+def test_dashboard_updates_with_new_profile(client, app_instance):
+    """New profile should change new-this-week count."""
+    with app_instance.app_context():
+        _create_athlete(created_at=datetime.utcnow() - timedelta(days=1))
+
+    _create_and_login_user(client, app_instance, 'updateuser')
+
+    resp = client.get('/dashboard')
+    html = resp.data.decode()
+    assert '>1<' in html
+
+    with app_instance.app_context():
+        _create_athlete(created_at=datetime.utcnow())
+
+    resp = client.get('/dashboard')
+    html = resp.data.decode()
+    assert '>2<' in html
+
+
+def test_dashboard_zero_and_percentage_formatting(client, app_instance):
+    """Counts should display 0 and percentage formatted correctly."""
+    with app_instance.app_context():
+        app_instance.config['CLIENT_SATISFACTION_PERCENT'] = 0.987
+
+    _create_and_login_user(client, app_instance, 'zerouser')
+
+    resp = client.get('/dashboard')
+    html = resp.data.decode()
+    assert html.count('>0<') >= 3
     assert '98.7%' in html
 


### PR DESCRIPTION
## Summary
- format dashboard counts and client satisfaction in the route
- add test helper for user login
- expand dashboard tests for total count, update behavior and formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865ecfcf3f8832798250bd67d545bec