### PR TITLE
Fix responsive stats grid on dashboard

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -90,3 +90,19 @@ body {
         font-size: 0.9rem;
     }
 }
+
+/* Stat cards grid */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+@media (max-width: 400px) {
+    .stats-grid .card-body {
+        padding: 0.75rem;
+    }
+    .stats-grid .display-6 {
+        font-size: 1.5rem;
+    }
+}

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -37,37 +37,29 @@
     </div>
 </div>
 
-<div class="row mt-4">
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h5 class="card-title">Total Athletes</h5>
-                <p class="display-6 nba">{{ total_athletes }}</p>
-            </div>
+<div class="stats-grid mt-4">
+    <div class="card text-center">
+        <div class="card-body">
+            <h5 class="card-title">Total Athletes</h5>
+            <p class="display-6 nba">{{ total_athletes }}</p>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h5 class="card-title">Active Contracts</h5>
-                <p class="display-6 nfl">{{ active_contracts }}</p>
-            </div>
+    <div class="card text-center">
+        <div class="card-body">
+            <h5 class="card-title">Active Contracts</h5>
+            <p class="display-6 nfl">{{ active_contracts }}</p>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h5 class="card-title">New This Week</h5>
-                <p class="display-6 mlb">{{ new_this_week }}</p>
-            </div>
+    <div class="card text-center">
+        <div class="card-body">
+            <h5 class="card-title">New This Week</h5>
+            <p class="display-6 mlb">{{ new_this_week }}</p>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h5 class="card-title">Client Satisfaction</h5>
-                <p class="display-6 nhl">{{ client_satisfaction }}%</p>
-            </div>
+    <div class="card text-center">
+        <div class="card-body">
+            <h5 class="card-title">Client Satisfaction</h5>
+            <p class="display-6 nhl">{{ client_satisfaction }}%</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- swap bootstrap row for CSS grid on dashboard stats
- add `.stats-grid` styles with responsive behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865ede90ad4832789c6e09c4b277fe6