### PR TITLE
Add athlete avatar support

### DIFF
--- a/app/api/athletes.py
+++ b/app/api/athletes.py
@@ -204,12 +204,16 @@ class FeaturedAthletes(Resource):
         year = date.today().year
         featured = []
         for ath in athletes:
+            name = ath.user.full_name if ath.user else ath.athlete_id
+            initials = "".join([n[0] for n in name.split()][:2]).upper()
             featured.append(
                 {
-                    "name": ath.user.full_name if ath.user else ath.athlete_id,
+                    "name": name,
                     "position": ath.primary_position.code if ath.primary_position else None,
                     "team": ath.current_team or "N/A",
                     "sport": ath.primary_sport.code if ath.primary_sport else None,
+                    "profile_image_url": ath.profile_image_url,
+                    "initials": initials,
                     "stats": _collect_featured_stats(ath, year),
                 }
             )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -108,12 +108,16 @@ def dashboard():
     )
     featured_athletes = []
     for ath in featured_profiles:
+        name = ath.user.full_name if ath.user else ath.athlete_id
+        initials = "".join([n[0] for n in name.split()][:2]).upper()
         featured_athletes.append(
             {
-                "name": ath.user.full_name if ath.user else ath.athlete_id,
+                "name": name,
                 "position": ath.primary_position.code if ath.primary_position else None,
                 "team": ath.current_team or "N/A",
                 "sport": ath.primary_sport.code if ath.primary_sport else None,
+                "profile_image_url": ath.profile_image_url,
+                "initials": initials,
                 "stats": _collect_featured_stats(ath, year),
             }
         )

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -61,6 +61,30 @@ body {
     border-radius: 50%;
 }
 
+/* Athlete photo/initials styles */
+.athlete-photo {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
+    color: #fff;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+img.athlete-photo {
+    background: none;
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
 /* Homepage search section */
 .search-section {
     max-width: 600px;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -34,9 +34,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const body = document.createElement('div');
     body.className = 'card-body';
 
+    const header = document.createElement('div');
+    header.className = 'd-flex align-items-center mb-2';
+
+    let photoEl;
+    if (ath.profile_image_url) {
+      photoEl = document.createElement('img');
+      photoEl.className = 'athlete-photo me-2';
+      photoEl.src = ath.profile_image_url;
+      photoEl.alt = `${ath.user.full_name} photo`;
+    } else {
+      photoEl = document.createElement('div');
+      photoEl.className = 'athlete-photo me-2';
+      const initials = ath.user.full_name
+        .split(/\s+/)
+        .slice(0, 2)
+        .map((n) => n[0])
+        .join('')
+        .toUpperCase();
+      photoEl.textContent = initials;
+    }
+
     const title = document.createElement('h5');
-    title.className = 'card-title';
+    title.className = 'card-title mb-0';
     title.textContent = ath.user.full_name;
+
+    header.appendChild(photoEl);
+    header.appendChild(title);
 
     const team = document.createElement('p');
     team.className = 'card-text';
@@ -51,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
     link.className = 'btn btn-primary btn-sm';
     link.textContent = 'View';
 
-    body.appendChild(title);
+    body.appendChild(header);
     body.appendChild(team);
     body.appendChild(rating);
     body.appendChild(link);

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -71,7 +71,14 @@
         <div class="col">
             <div class="athlete-card card h-100">
                 <div class="card-body">
-                    <h5 class="athlete-name card-title">{{ athlete.name }}</h5>
+                    <div class="d-flex align-items-center mb-2">
+                        {% if athlete.profile_image_url %}
+                        <img src="{{ athlete.profile_image_url }}" alt="{{ athlete.name }} photo" class="athlete-photo me-2">
+                        {% else %}
+                        <div class="athlete-photo me-2">{{ athlete.initials }}</div>
+                        {% endif %}
+                        <h5 class="athlete-name card-title mb-0">{{ athlete.name }}</h5>
+                    </div>
                     <p class="athlete-details text-muted">{{ athlete.position }} • {{ athlete.team }} • {{ athlete.sport }}</p>
                     <div class="d-flex justify-content-between">
                         {% for stat in athlete.stats %}


### PR DESCRIPTION
## Summary
- support profile image URLs in featured athlete dashboards
- expose image URL and initials via `/api/athletes/featured`
- show avatar or initials on dashboard cards and search results
- style `.athlete-photo` placeholders and images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68669139c5d083279aa381de9e41a477