### PR TITLE
Add Add New Athlete action

### DIFF
--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -31,6 +31,11 @@
                     <li><a href="#" class="text-decoration-none">Edit Profile</a></li>
                     <li><a href="#" class="text-decoration-none">Account Settings</a></li>
                     <li><a href="#" class="text-decoration-none">Privacy Settings</a></li>
+                    {% if current_user.has_role('agency_admin') or current_user.has_role('admin') %}
+                    <li>
+                        <a href="{{ url_for('athletes.create') }}" class="action-btn btn-primary">&#43; Add New Athlete</a>
+                    </li>
+                    {% endif %}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add link on dashboard to create a new athlete profile when user has the proper role

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686692978d2883278e2c6cc35fd7e62f