### PR TITLE
Integrate rankings list into dashboard

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -131,6 +131,26 @@ def dashboard():
     if satisfaction_value <= 1.0:
         satisfaction_value *= 100
     client_satisfaction = f"{satisfaction_value:.1f}"
+
+    rankings_query = (
+        AthleteProfile.query.filter_by(is_deleted=False)
+        .join(User)
+        .outerjoin(Sport)
+        .order_by(AthleteProfile.overall_rating.desc())
+        .limit(10)
+    )
+    rankings = []
+    for ath in rankings_query:
+        name = ath.user.full_name if ath.user else ath.athlete_id
+        rankings.append(
+            {
+                "name": name,
+                "team": ath.current_team or "N/A",
+                "sport": ath.primary_sport.code if ath.primary_sport else None,
+                "rating": float(ath.overall_rating or 0),
+            }
+        )
+
     return render_template(
         'main/dashboard.html',
         user_name=user_name,
@@ -139,6 +159,7 @@ def dashboard():
         new_this_week=new_this_week,
         client_satisfaction=client_satisfaction,
         featured_athletes=featured_athletes,
+        rankings=rankings,
     )
 
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('ranking-search');
+  const items = document.querySelectorAll('#ranking-list .ranking-item');
+  if (!input || !items.length) return;
+
+  input.addEventListener('input', () => {
+    const q = input.value.trim().toLowerCase();
+    items.forEach((li) => {
+      const name = li.dataset.name.toLowerCase();
+      li.style.display = name.includes(q) ? '' : 'none';
+    });
+  });
+});

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -103,9 +103,26 @@
         {% endfor %}
     </div>
 </div>
+
+<div class="rankings mt-5">
+    <h3>Top Ranked Athletes</h3>
+    <input type="text" id="ranking-search" class="form-control mb-3" placeholder="Filter athletes...">
+    <ul id="ranking-list" class="list-group">
+        {% for athlete in rankings %}
+        <li class="list-group-item d-flex justify-content-between align-items-center ranking-item" data-name="{{ athlete.name }}">
+            <span>{{ loop.index }}. {{ athlete.name }} - {{ athlete.team }} ({{ athlete.sport }})</span>
+            <span class="badge bg-secondary">{{ athlete.rating }}</span>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
 {% else %}
 <div class="alert alert-info">
     Please <a href="{{ url_for('auth.login') }}">login</a> to access your dashboard.
 </div>
 {% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compile top rated athlete rankings server side
- display rankings and search field in dashboard
- add new dashboard.js for filtering the ranking list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6866ff7724fc8327a0657030eca6bbff