### PR TITLE
Add placeholder rankings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ a formula or survey data to calculate it dynamically.
 
 An **📊 View Analytics** button now links to `/analytics`. This page simply states "Coming soon" until full reporting features arrive in Phase 5.
 A **📁 Upload Media** button in the dashboard directs to `/media/upload` where administrators can attach files to athlete profiles.
+The API exposes a `/api/rankings/top` endpoint returning five placeholder athletes with an overall score. These values remain static until a real ranking system is implemented.

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -15,4 +15,4 @@ api = Api(
 )
 
 # Import resources to register endpoints with this Api
-from app.api import routes, athletes, skills  # noqa: E402
+from app.api import routes, athletes, skills, rankings  # noqa: E402

--- a/app/api/rankings.py
+++ b/app/api/rankings.py
@@ -1,0 +1,35 @@
+from flask import jsonify, current_app
+from flask_restx import Resource
+import json
+import os
+
+from app.api import api
+
+
+_DEFAULT_RANKINGS = [
+    {"name": "LeBron James", "score": 98.5},
+    {"name": "Connor McDavid", "score": 97.8},
+    {"name": "Mike Trout", "score": 96.2},
+    {"name": "Aaron Donald", "score": 95.7},
+    {"name": "Stephen Curry", "score": 94.9},
+]
+
+
+def _load_rankings():
+    """Load rankings from file if configured, otherwise return defaults."""
+    path = current_app.config.get("TOP_RANKINGS_FILE")
+    if path and os.path.exists(path):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            current_app.logger.exception("Failed to load rankings file %s", path)
+    return _DEFAULT_RANKINGS
+
+
+@api.route('/rankings/top')
+class TopRankings(Resource):
+    """Return the top 5 athlete rankings with placeholder scores."""
+
+    def get(self):
+        return jsonify(_load_rankings())

--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ class Config:
     NFL_API_BASE_URL = os.environ.get("NFL_API_BASE_URL") or "https://api.nfl.com/v1"
     NHL_API_BASE_URL = os.environ.get("NHL_API_BASE_URL") or "https://statsapi.web.nhl.com/api/v1"
     CLIENT_SATISFACTION_PERCENT = float(os.environ.get('CLIENT_SATISFACTION_PERCENT', '98.7'))
+    TOP_RANKINGS_FILE = os.environ.get('TOP_RANKINGS_FILE')
     ENABLE_SCHEDULER = os.environ.get('ENABLE_SCHEDULER', 'false').lower() == 'true'
 
 class DevelopmentConfig(Config):

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -34,3 +34,9 @@ All API routes are prefixed with `/api`. Authentication is required for endpoint
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
 | GET | `/api/athletes/search` | Search athletes using query parameters such as `q`, `sport`, `position`, `team`, age/height/weight filters and the `filter` tab (nba, nfl, mlb, nhl, available, top). |
+
+## Rankings
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/rankings/top` | Return a placeholder list of the top five athletes with an overall score. |

--- a/docs/phase3_notes.md
+++ b/docs/phase3_notes.md
@@ -8,6 +8,10 @@ In a future phase the client may provide survey data or a formula for calculatin
 
 The dashboard now includes a **📊 View Analytics** button linking to `/analytics`. This route displays a "Coming soon" message. Full reporting features are planned for Phase 5, so this button and page act as placeholders in Phase 3.
 
+## Top Rankings
+
+A `/api/rankings/top` endpoint returns five hard-coded athletes with an overall score. This serves as an interim data source until the multi-factor ranking system is developed in Phase 4.
+
 ## Media upload
 
 A new **📁 Upload Media** option on the dashboard links to `/media/upload`. The page presents a simple form to pick an athlete and upload a file. This demonstrates the media workflow from Phase 2 without persisting large files during the demo.

--- a/tests/test_rankings_api.py
+++ b/tests/test_rankings_api.py
@@ -1,0 +1,33 @@
+import json
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+
+
+@pytest.fixture
+def app_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path / "test.db"}')
+    app = create_app('testing')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def test_top_rankings_placeholder(client):
+    resp = client.get('/api/rankings/top')
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert isinstance(data, list)
+    assert len(data) == 5
+    assert 'name' in data[0] and 'score' in data[0]


### PR DESCRIPTION
## Summary
- provide placeholder top rankings data via `/api/rankings/top`
- load from optional file via `TOP_RANKINGS_FILE` setting
- document the new endpoint and placeholder rankings in README and phase notes
- add tests for the rankings API

## Testing
- `pytest tests/test_rankings_api.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686701c1cec483278c6a1638553d97e2