### PR TITLE
Add simple dynamic rankings

### DIFF
--- a/app/api/rankings.py
+++ b/app/api/rankings.py
@@ -2,8 +2,10 @@ from flask import jsonify, current_app
 from flask_restx import Resource
 import json
 import os
+from sqlalchemy.orm import joinedload
 
 from app.api import api
+from app.models import AthleteProfile, AthleteStat
 
 
 _DEFAULT_RANKINGS = [
@@ -27,9 +29,82 @@ def _load_rankings():
     return _DEFAULT_RANKINGS
 
 
+_SPORT_STAT = {
+    "NBA": "PointsPerGame",
+    "NFL": "PassingYards",
+    "MLB": "BattingAverage",
+    "NHL": "Points",
+}
+
+# Rough maximum values used to scale a stat to 0-100. These heuristics are only
+# for the placeholder algorithm and will be replaced in Phase 4.
+_STAT_MAX = {
+    "PointsPerGame": 35,
+    "PassingYards": 5000,
+    "BattingAverage": 0.35,
+    "Points": 120,
+}
+
+
+def _calculate_simple_score(athlete):
+    """Return a naive 0-100 score using one key stat per sport.
+
+    This function is a **temporary stand-in** until the real multi-metric
+    ranking algorithm arrives in Phase 4. It looks up a single stat for the
+    athlete (e.g. NBA points per game) and scales it using a rough maximum
+    value.
+    """
+
+    base = float(athlete.overall_rating or 0)
+    sport_code = athlete.primary_sport.code if athlete.primary_sport else None
+    stat_name = _SPORT_STAT.get(sport_code)
+    if not stat_name:
+        return base
+
+    stat = (
+        AthleteStat.query.filter_by(athlete_id=athlete.athlete_id, name=stat_name)
+        .order_by(AthleteStat.season.desc())
+        .first()
+    )
+    if not stat:
+        return base
+    try:
+        value = float(stat.value)
+    except (TypeError, ValueError):
+        return base
+
+    max_val = _STAT_MAX.get(stat_name) or 1
+    score = (value / max_val) * 100
+    return round(min(score, 100), 1)
+
+
+def _dynamic_rankings(limit=5):
+    """Compute rankings for athletes using the simple scoring formula."""
+
+    athletes = (
+        AthleteProfile.query.options(joinedload(AthleteProfile.user))
+        .options(joinedload(AthleteProfile.primary_sport))
+        .filter_by(is_deleted=False)
+        .all()
+    )
+    if not athletes:
+        return None
+
+    ranked = []
+    for ath in athletes:
+        name = ath.user.full_name if ath.user else ath.athlete_id
+        ranked.append({"name": name, "score": _calculate_simple_score(ath)})
+
+    ranked.sort(key=lambda r: r["score"], reverse=True)
+    return ranked[:limit]
+
+
 @api.route('/rankings/top')
 class TopRankings(Resource):
-    """Return the top 5 athlete rankings with placeholder scores."""
+    """Return the top 5 athlete rankings using a temporary formula."""
 
     def get(self):
-        return jsonify(_load_rankings())
+        rankings = _dynamic_rankings()
+        if rankings is None:
+            rankings = _load_rankings()
+        return jsonify(rankings)

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -39,4 +39,4 @@ All API routes are prefixed with `/api`. Authentication is required for endpoint
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| GET | `/api/rankings/top` | Return a placeholder list of the top five athletes with an overall score. |
+| GET | `/api/rankings/top` | Return the top five athletes using a temporary single-stat score (falls back to a small static list). |

--- a/docs/phase3_notes.md
+++ b/docs/phase3_notes.md
@@ -10,7 +10,12 @@ The dashboard now includes a **📊 View Analytics** button linking to `/analyti
 
 ## Top Rankings
 
-A `/api/rankings/top` endpoint returns five hard-coded athletes with an overall score. This serves as an interim data source until the multi-factor ranking system is developed in Phase 4.
+The `/api/rankings/top` endpoint now calculates a basic ranking from any
+athletes stored in the database. It uses a simple single-stat formula for each
+sport (for example NBA points per game) to assign a score out of 100. If no
+athlete data exists it will still return a small hard-coded list. This logic is
+explicitly temporary and will be replaced by a multi-metric algorithm in
+Phase 4.
 
 ## Media upload
 

--- a/tests/test_rankings_api.py
+++ b/tests/test_rankings_api.py
@@ -1,11 +1,14 @@
 import json
 import os
 import sys
+import uuid
+from datetime import date
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app import create_app, db
+from app.models import User, AthleteProfile, AthleteStat, Sport
 
 
 @pytest.fixture
@@ -24,10 +27,55 @@ def client(app_instance):
     return app_instance.test_client()
 
 
-def test_top_rankings_placeholder(client):
-    resp = client.get('/api/rankings/top')
+def _create_athlete(sport_code, stat_value):
+    sport = Sport.query.filter_by(code=sport_code).first()
+    if not sport:
+        sport = Sport(name=sport_code, code=sport_code)
+        db.session.add(sport)
+        db.session.commit()
+
+    user = User(
+        username=str(uuid.uuid4()),
+        email=f"{uuid.uuid4()}@example.com",
+        first_name="F",
+        last_name="L",
+    )
+    user.save()
+
+    athlete = AthleteProfile(
+        user_id=user.user_id,
+        primary_sport_id=sport.sport_id,
+        date_of_birth=date.fromisoformat("2000-01-01"),
+    )
+    athlete.save()
+
+    stat_name = {
+        "NBA": "PointsPerGame",
+        "NHL": "Points",
+    }[sport_code]
+
+    stat = AthleteStat(
+        athlete_id=athlete.athlete_id,
+        name=stat_name,
+        value=str(stat_value),
+        season="2024",
+    )
+    db.session.add(stat)
+    db.session.commit()
+    return athlete
+
+
+def test_top_rankings_dynamic(client, app_instance):
+    with app_instance.app_context():
+        a1 = _create_athlete("NBA", 30)
+        a2 = _create_athlete("NBA", 20)
+        a3 = _create_athlete("NHL", 50)
+        top_name = a1.user.full_name
+
+    resp = client.get("/api/rankings/top")
     assert resp.status_code == 200
     data = json.loads(resp.data)
-    assert isinstance(data, list)
-    assert len(data) == 5
-    assert 'name' in data[0] and 'score' in data[0]
+    assert len(data) == 3
+    assert data[0]["name"] == top_name
+    scores = [r["score"] for r in data]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- compute dynamic rankings using a single-stat formula when athlete data exists
- document the temporary approach in Phase 3 notes and API docs
- update ranking tests for the new behavior

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686702ce6f248327a29ca9faa4cce31f