### PR TITLE
Add rankings list page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -178,3 +178,15 @@ def upload_media():
             flash('Media uploaded successfully.', 'success')
             return redirect(url_for('athletes.detail', athlete_id=athlete_id))
     return render_template('main/upload_media.html', athletes=athletes)
+
+
+@bp.route('/rankings')
+def rankings():
+    """Display the top athlete rankings."""
+    from app.api.rankings import _dynamic_rankings, _load_rankings
+
+    rankings = _dynamic_rankings()
+    if rankings is None:
+        rankings = _load_rankings()
+
+    return render_template('main/rankings.html', top_rankings=rankings)

--- a/templates/main/base.html
+++ b/templates/main/base.html
@@ -21,6 +21,7 @@
             
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="{{ url_for('athletes.index') }}">Athletes</a>
+                <a class="nav-link" href="{{ url_for('main.rankings') }}">Rankings</a>
                 {% if current_user.is_authenticated %}
                 <a class="nav-link" href="{{ url_for('main.dashboard') }}">Dashboard</a>
                 <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>

--- a/templates/main/rankings.html
+++ b/templates/main/rankings.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Top Rankings - {{ super() }}{% endblock %}
+
+{% block content %}
+<div class="rankings-list">
+  {% for player in top_rankings %}
+  <div class="ranking-item">
+    <div class="rank-number">{{ loop.index }}</div>
+    <div class="ranking-info">
+      <div class="ranking-name">{{ player.name }}</div>
+      <div class="ranking-score">Overall Score: {{ '%.1f'|format(player.score|float) }}</div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/rankings` route to show top athletes
- display ranking data in a new template
- link Rankings in the main navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6867042f99908327a74d55e07b754f8a