### PR TITLE
Add placeholder rankings page and button

### DIFF
--- a/app/api/rankings.py
+++ b/app/api/rankings.py
@@ -14,6 +14,11 @@ _DEFAULT_RANKINGS = [
     {"name": "Mike Trout", "score": 96.2},
     {"name": "Aaron Donald", "score": 95.7},
     {"name": "Stephen Curry", "score": 94.9},
+    {"name": "Giannis Antetokounmpo", "score": 94.0},
+    {"name": "Patrick Mahomes", "score": 93.5},
+    {"name": "Sidney Crosby", "score": 92.8},
+    {"name": "Shohei Ohtani", "score": 92.2},
+    {"name": "Lionel Messi", "score": 91.7},
 ]
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -182,10 +182,12 @@ def upload_media():
 
 @bp.route('/rankings')
 def rankings():
-    """Display the top athlete rankings."""
+    """Display the full rankings placeholder page."""
+    # NOTE: This is a temporary page until the comprehensive
+    # ranking algorithm is implemented in Phase 4.
     from app.api.rankings import _dynamic_rankings, _load_rankings
 
-    rankings = _dynamic_rankings()
+    rankings = _dynamic_rankings(limit=10)
     if rankings is None:
         rankings = _load_rankings()
 

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -42,6 +42,9 @@
                     <li>
                         <a href="{{ url_for('main.analytics') }}" class="text-decoration-none">📊 View Analytics</a>
                     </li>
+                    <li>
+                        <a href="{{ url_for('main.rankings') }}" class="text-decoration-none">📈 View Full Rankings</a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/templates/main/rankings.html
+++ b/templates/main/rankings.html
@@ -3,6 +3,7 @@
 {% block title %}Top Rankings - {{ super() }}{% endblock %}
 
 {% block content %}
+<p class="text-muted">Full rankings page under development.</p>
 <div class="rankings-list">
   {% for player in top_rankings %}
   <div class="ranking-item">


### PR DESCRIPTION
## Summary
- add more default rankings data
- update rankings route to show placeholder
- link new rankings page from dashboard actions
- display notice in ranking template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68670767d264832794c50741ede98749