### PR TITLE
Add placeholder modal for Customize Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ a formula or survey data to calculate it dynamically.
 An **📊 View Analytics** button now links to `/analytics`. This page simply states "Coming soon" until full reporting features arrive in Phase 5.
 A **📁 Upload Media** button in the dashboard directs to `/media/upload` where administrators can attach files to athlete profiles.
 The API exposes a `/api/rankings/top` endpoint returning five placeholder athletes with an overall score. These values remain static until a real ranking system is implemented.
+The rankings page also includes a **⚙️ Customize Metrics** button. Clicking it opens a modal explaining that ranking weight adjustments are coming in a future phase.

--- a/docs/phase3_notes.md
+++ b/docs/phase3_notes.md
@@ -20,3 +20,7 @@ Phase 4.
 ## Media upload
 
 A new **📁 Upload Media** option on the dashboard links to `/media/upload`. The page presents a simple form to pick an athlete and upload a file. This demonstrates the media workflow from Phase 2 without persisting large files during the demo.
+
+## Customize Metrics button
+
+The rankings page now displays a **⚙️ Customize Metrics** button. In Phase 3 this opens a modal dialog explaining the feature is coming soon. The modal shows read-only sliders for weighting factors to signal future support for ranking customization.

--- a/static/js/customize_metrics.js
+++ b/static/js/customize_metrics.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('customize-metrics-btn');
+  if (btn) {
+    new bootstrap.Tooltip(btn);
+  }
+});

--- a/templates/main/rankings.html
+++ b/templates/main/rankings.html
@@ -3,7 +3,14 @@
 {% block title %}Top Rankings - {{ super() }}{% endblock %}
 
 {% block content %}
-<p class="text-muted">Full rankings page under development.</p>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <p class="text-muted mb-0">Full rankings page under development.</p>
+  <button id="customize-metrics-btn" type="button" class="btn btn-outline-secondary"
+          data-bs-toggle="modal" data-bs-target="#metricsModal"
+          title="Metric customization coming in a future phase">
+    ⚙️ Customize Metrics
+  </button>
+</div>
 <div class="rankings-list">
   {% for player in top_rankings %}
   <div class="ranking-item">
@@ -15,4 +22,36 @@
   </div>
   {% endfor %}
 </div>
+
+<!-- Placeholder modal -->
+<div class="modal fade" id="metricsModal" tabindex="-1" aria-labelledby="metricsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="metricsModalLabel">Customize Metrics</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted">Feature coming soon.</p>
+        <form>
+          <div class="mb-3">
+            <label for="statWeight" class="form-label">Statistical Performance</label>
+            <input type="range" class="form-range" id="statWeight" min="0" max="100" value="50" disabled>
+          </div>
+          <div class="mb-3">
+            <label for="fanWeight" class="form-label">Fan Perception</label>
+            <input type="range" class="form-range" id="fanWeight" min="0" max="100" value="50" disabled>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/customize_metrics.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- stub out non-functional **Customize Metrics** button
- log placeholder in Phase 3 docs and README
- script to enable button tooltip

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867093d28648327a45212bf52c1806b