### PR TITLE
Ensure rankings link to profiles

### DIFF
--- a/app/api/rankings.py
+++ b/app/api/rankings.py
@@ -39,6 +39,7 @@ _SPORT_STAT = {
     "NFL": "PassingYards",
     "MLB": "BattingAverage",
     "NHL": "Points",
+    "SOC": "Goals",
 }
 
 # Rough maximum values used to scale a stat to 0-100. These heuristics are only
@@ -48,6 +49,7 @@ _STAT_MAX = {
     "PassingYards": 5000,
     "BattingAverage": 0.35,
     "Points": 120,
+    "Goals": 60,
 }
 
 
@@ -98,7 +100,11 @@ def _dynamic_rankings(limit=5):
     ranked = []
     for ath in athletes:
         name = ath.user.full_name if ath.user else ath.athlete_id
-        ranked.append({"name": name, "score": _calculate_simple_score(ath)})
+        ranked.append({
+            "id": ath.athlete_id,
+            "name": name,
+            "score": _calculate_simple_score(ath),
+        })
 
     ranked.sort(key=lambda r: r["score"], reverse=True)
     return ranked[:limit]

--- a/run.py
+++ b/run.py
@@ -106,6 +106,17 @@ def init_db():
                 {'name': 'Defenseman', 'code': 'D', 'description': 'Defensive player'},
                 {'name': 'Goaltender', 'code': 'G', 'description': 'Goal keeper'}
             ]
+        },
+        {
+            'name': 'Soccer',
+            'code': 'SOC',
+            'description': 'International Federation of Association Football',
+            'positions': [
+                {'name': 'Forward', 'code': 'FW', 'description': 'Primary attacker'},
+                {'name': 'Midfielder', 'code': 'MF', 'description': 'Midfield player'},
+                {'name': 'Defender', 'code': 'DF', 'description': 'Defensive player'},
+                {'name': 'Goalkeeper', 'code': 'GK', 'description': 'Goal keeper'}
+            ]
         }
     ]
     
@@ -223,6 +234,135 @@ def seed_demo():
             ],
             'stats': [
                 {'name': 'Points', 'value': '1525'},
+            ],
+        },
+        {
+            'username': 'cmcdavid',
+            'email': 'mcdavid@example.com',
+            'first_name': 'Connor',
+            'last_name': 'McDavid',
+            'dob': date(1997, 1, 13),
+            'sport': 'NHL',
+            'position': 'C',
+            'nationality': 'CAN',
+            'skills': [
+                {'name': 'Speed', 'level': 'expert'},
+                {'name': 'Playmaking', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'Points', 'value': '153'},
+            ],
+        },
+        {
+            'username': 'mtrout',
+            'email': 'trout@example.com',
+            'first_name': 'Mike',
+            'last_name': 'Trout',
+            'dob': date(1991, 8, 7),
+            'sport': 'MLB',
+            'position': '1B',
+            'nationality': 'USA',
+            'skills': [
+                {'name': 'Power', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'BattingAverage', 'value': '0.304'},
+            ],
+        },
+        {
+            'username': 'adonald',
+            'email': 'donald@example.com',
+            'first_name': 'Aaron',
+            'last_name': 'Donald',
+            'dob': date(1991, 5, 23),
+            'sport': 'NFL',
+            'position': 'OL',
+            'nationality': 'USA',
+            'skills': [
+                {'name': 'Strength', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'PassingYards', 'value': '0'},
+            ],
+        },
+        {
+            'username': 'scurry',
+            'email': 'curry@example.com',
+            'first_name': 'Stephen',
+            'last_name': 'Curry',
+            'dob': date(1988, 3, 14),
+            'sport': 'NBA',
+            'position': 'PG',
+            'nationality': 'USA',
+            'skills': [
+                {'name': 'Shooting', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'PPG', 'value': '24.6'},
+            ],
+        },
+        {
+            'username': 'giannis',
+            'email': 'giannis@example.com',
+            'first_name': 'Giannis',
+            'last_name': 'Antetokounmpo',
+            'dob': date(1994, 12, 6),
+            'sport': 'NBA',
+            'position': 'PF',
+            'nationality': 'GRC',
+            'skills': [
+                {'name': 'Athleticism', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'PPG', 'value': '30.2'},
+            ],
+        },
+        {
+            'username': 'pmahomes',
+            'email': 'mahomes@example.com',
+            'first_name': 'Patrick',
+            'last_name': 'Mahomes',
+            'dob': date(1995, 9, 17),
+            'sport': 'NFL',
+            'position': 'QB',
+            'nationality': 'USA',
+            'skills': [
+                {'name': 'Passing', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'PassingYards', 'value': '5250'},
+            ],
+        },
+        {
+            'username': 'sohtani',
+            'email': 'ohtani@example.com',
+            'first_name': 'Shohei',
+            'last_name': 'Ohtani',
+            'dob': date(1994, 7, 5),
+            'sport': 'MLB',
+            'position': 'P',
+            'nationality': 'JPN',
+            'skills': [
+                {'name': 'Two-Way', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'BattingAverage', 'value': '0.304'},
+            ],
+        },
+        {
+            'username': 'lmessi',
+            'email': 'messi@example.com',
+            'first_name': 'Lionel',
+            'last_name': 'Messi',
+            'dob': date(1987, 6, 24),
+            'sport': 'SOC',
+            'position': 'FW',
+            'nationality': 'ARG',
+            'skills': [
+                {'name': 'Dribbling', 'level': 'expert'},
+            ],
+            'stats': [
+                {'name': 'Goals', 'value': '30'},
             ],
         },
     ]

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -82,7 +82,7 @@
     <h3>Featured Athletes</h3>
     <div class="athlete-grid">
         {% for athlete in featured_athletes %}
-        <a href="{{ url_for('athletes.view', id=athlete.athlete_id) }}" class="athlete-card card h-100 text-decoration-none">
+        <a href="{{ url_for('athletes.detail', athlete_id=athlete.athlete_id) }}" class="athlete-card card h-100 text-decoration-none">
             <div class="card-body">
                 <div class="d-flex align-items-center mb-2">
                     {% if athlete.profile_image_url %}

--- a/templates/main/rankings.html
+++ b/templates/main/rankings.html
@@ -16,7 +16,13 @@
   <div class="ranking-item">
     <div class="rank-number">{{ loop.index }}</div>
     <div class="ranking-info">
-      <div class="ranking-name">{{ player.name }}</div>
+      <div class="ranking-name">
+        {% if player.id %}
+        <a href="{{ url_for('athletes.detail', athlete_id=player.id) }}" class="text-decoration-none">{{ player.name }}</a>
+        {% else %}
+        {{ player.name }}
+        {% endif %}
+      </div>
       <div class="ranking-score">Overall Score: {{ '%.1f'|format(player.score|float) }}</div>
     </div>
   </div>

--- a/tests/test_rankings_api.py
+++ b/tests/test_rankings_api.py
@@ -77,5 +77,6 @@ def test_top_rankings_dynamic(client, app_instance):
     data = json.loads(resp.data)
     assert len(data) == 3
     assert data[0]["name"] == top_name
+    assert data[0]["id"]
     scores = [r["score"] for r in data]
     assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- include soccer sport and default player data
- seed database with all ranking athletes
- link ranking names to athlete profiles
- provide athlete ID through the ranking API
- update ranking tests accordingly
- fix featured athlete link target

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68670c37c99483279d04cc8702a9108f