### PR TITLE
Integrate rankings data into dashboard

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, date
 from app import db
 from app.models import AthleteProfile, AthleteStat, AthleteMedia, User, Sport, Position
 from app.services.media_service import MediaService
+from app.api.rankings import _dynamic_rankings, _load_rankings
 from app.utils.auth import oauth_session_required
 from app.main import bp
 
@@ -131,6 +132,11 @@ def dashboard():
     if satisfaction_value <= 1.0:
         satisfaction_value *= 100
     client_satisfaction = f"{satisfaction_value:.1f}"
+
+    rankings = _dynamic_rankings(limit=5)
+    if rankings is None:
+        rankings = _load_rankings()[:5]
+
     return render_template(
         'main/dashboard.html',
         user_name=user_name,
@@ -139,6 +145,7 @@ def dashboard():
         new_this_week=new_this_week,
         client_satisfaction=client_satisfaction,
         featured_athletes=featured_athletes,
+        top_rankings=rankings,
     )
 
 

--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -106,9 +106,34 @@
         {% endfor %}
     </div>
 </div>
+
+<div class="top-rankings mt-5">
+    <h3>Top Rankings</h3>
+    <div class="rankings-list">
+        {% for player in top_rankings %}
+        <div class="ranking-item">
+            <div class="rank-number">{{ loop.index }}</div>
+            <div class="ranking-info">
+                <div class="ranking-name">
+                    {% if player.id %}
+                    <a href="{{ url_for('athletes.detail', athlete_id=player.id) }}" class="text-decoration-none">{{ player.name }}</a>
+                    {% else %}
+                    {{ player.name }}
+                    {% endif %}
+                </div>
+                <div class="ranking-score">Overall Score: {{ '%.1f'|format(player.score|float) }}</div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
 {% else %}
 <div class="alert alert-info">
     Please <a href="{{ url_for('auth.login') }}">login</a> to access your dashboard.
 </div>
 {% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/search.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- pull ranking helpers into dashboard view
- return rankings with other dashboard stats
- render top rankings list on the dashboard
- include search JS on dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68674baee05483278766c65761469d69