### PR TITLE
Add indexes for name search

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ flask db upgrade
 
 The latest migrations add indexes on stat tables for faster lookups. Run the
 above command whenever pulling new code to ensure these indexes exist.
+The August 1 migration adds indexes on user first and last name and current team to speed up searches.
 The July 15 migration also enforces unique season and game stats and
 checks that game scores are non-negative.
 

--- a/migrations/versions/e8b9f47f3d4a_add_user_name_indexes.py
+++ b/migrations/versions/e8b9f47f3d4a_add_user_name_indexes.py
@@ -1,0 +1,28 @@
+"""add indexes for name search
+
+Revision ID: e8b9f47f3d4a
+Revises: d963424f23ab
+Create Date: 2025-08-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e8b9f47f3d4a'
+down_revision = 'd963424f23ab'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('idx_users_first_name', 'users', ['first_name'])
+    op.create_index('idx_users_last_name', 'users', ['last_name'])
+    op.create_index('idx_athletes_current_team', 'athlete_profiles', ['current_team'])
+
+
+def downgrade():
+    op.drop_index('idx_athletes_current_team', table_name='athlete_profiles')
+    op.drop_index('idx_users_last_name', table_name='users')
+    op.drop_index('idx_users_first_name', table_name='users')
+


### PR DESCRIPTION
## Summary
- add a migration to create indexes on user name and current team
- mention the new migration in the README

## Testing
- `pytest -k query_performance -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6867517a26d48327b573e6a3a6db1e86