### PR TITLE
Document dashboard scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ This starts the Flask server on port `5000` and a Postgres database on `5432`.
 
 The React frontend is regularly tested on the latest versions of Chrome, Firefox, Safari and Edge. Other modern browsers that support ES2015+ features should also work.
 
+## Dashboard features (Phases 1–3)
+
+The `/dashboard` page implements the core capabilities delivered so far:
+
+- Quick action links for editing a profile, managing account settings and, for administrators, adding new athletes.
+- Buttons for **📁 Upload Media** and **📊 View Analytics** which lead to placeholder pages.
+- Summary metrics showing total athletes, active contracts, new signups this week and a placeholder **Client Satisfaction** percentage.
+- Featured athlete cards displaying position, team and sport information.
+- A Top Rankings preview calculated using a simple single-stat formula. A **⚙️ Customize Metrics** modal hints at future ranking options.
+
+Advanced search and a full ranking algorithm are deferred until Phase 4. Mobile apps and cloud deployment are out of scope; the project targets local web use only.
+
 ## Checking layout on mobile vs. desktop
 
 To verify the responsive design manually:

--- a/docs/phase3_notes.md
+++ b/docs/phase3_notes.md
@@ -24,3 +24,10 @@ A new **📁 Upload Media** option on the dashboard links to `/media/upload`. Th
 ## Customize Metrics button
 
 The rankings page now displays a **⚙️ Customize Metrics** button. In Phase 3 this opens a modal dialog explaining the feature is coming soon. The modal shows read-only sliders for weighting factors to signal future support for ranking customization.
+
+## Out of scope
+
+Mobile applications and a cloud-hosted deployment are not included in Phases 1–3.
+The search bar on the homepage performs only basic filtering and the ranking
+algorithm is a simple placeholder. More advanced functionality will arrive in
+later phases.


### PR DESCRIPTION
## Summary
- document dashboard features in the README
- clarify out-of-scope items in Phase 3 notes

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867537196288327b31a981110d0ab43